### PR TITLE
fix: quantitative value estimation for femoral cartilage

### DIFF
--- a/tissues/femoral_cartilage.py
+++ b/tissues/femoral_cartilage.py
@@ -124,7 +124,8 @@ class FemoralCartilage(Tissue):
             polar_coords = np.concatenate(
                 (theta.reshape(dim, 1), rho.reshape(dim, 1), non_zero_T2_slice_values.reshape(dim, 1)), axis=1)
 
-            angles = np.linspace(-180, 175, num=72)
+            dtheta = 360 / nb_bins
+            angles = np.linspace(-180, 180-dtheta, num=nb_bins)
 
             for angle in angles:
                 bottom_bin = angle

--- a/tissues/femoral_cartilage.py
+++ b/tissues/femoral_cartilage.py
@@ -44,7 +44,7 @@ class FemoralCartilage(Tissue):
     POSTERIOR_KEY = 2 ** 0
     CENTRAL_KEY = 2 ** 1
     ANTERIOR_KEY = 2 ** 2
-    CORONAL_KEYS = [ANTERIOR_KEY, CENTRAL_KEY, POSTERIOR_KEY]
+    CORONAL_KEYS = [POSTERIOR_KEY, CENTRAL_KEY, ANTERIOR_KEY]
 
     # Saggital Keys
     MEDIAL_KEY = 2 ** 3
@@ -402,8 +402,8 @@ class FemoralCartilage(Tissue):
         coronal_region_mask = (coronal_region_mask + 1) * 10
         sagital_region_mask = (sagital_region_mask + 1)
         joined_mask = coronal_region_mask + sagital_region_mask
-        labels = ['medial anterior', 'medial central', 'medial posterior',
-                  'lateral anterior', 'lateral central', 'lateral posterior']
+        labels = ['medial posterior', 'medial central', 'medial anterior',
+                  'lateral posterior', 'lateral central', 'lateral anterior']
         plt_dict = {'labels': labels, 'xlabel': 'Slice', 'ylabel': 'Angle (binned)', 'title': 'Unrolled Regions'}
         img_utils.write_regions(os.path.join(save_dirpath, 'region_map.png'), joined_mask, plt_dict=plt_dict)
 

--- a/tissues/femoral_cartilage.py
+++ b/tissues/femoral_cartilage.py
@@ -104,12 +104,12 @@ class FemoralCartilage(Tissue):
         Deep_layer = np.float32(np.zeros((num_slices, nb_bins)))
 
         for i in np.array(range(num_slices)):
-
             segmented_T2maps_slice = segmented_T2maps[:, :, i]
 
             if np.max(segmented_T2maps_slice) == 0:
                 continue
 
+            import pdb; pdb.set_trace()
             non_zero_slice_element = np.nonzero(segmented_T2maps_slice)
             non_zero_T2_slice_values = segmented_T2maps_slice[segmented_T2maps_slice > 0]
             dim = non_zero_T2_slice_values.shape[0]
@@ -131,7 +131,7 @@ class FemoralCartilage(Tissue):
                 bottom_bin = angle
                 top_bin = angle + dtheta
 
-                splice_matrix = np.where((polar_coords[:, 0] > bottom_bin) & (polar_coords[:, 0] <= top_bin))
+                splice_matrix = np.where((polar_coords[:, 0] >= bottom_bin) & (polar_coords[:, 0] < top_bin))
 
                 binned_result = polar_coords[splice_matrix[0], :]
 
@@ -148,7 +148,7 @@ class FemoralCartilage(Tissue):
                 splice_deep = np.where(binned_result[:, 1] <= rad_division)
                 binned_deep = binned_result[splice_deep]
 
-                splice_super = np.where(binned_result[:, 1] >= rad_division)
+                splice_super = np.where(binned_result[:, 1] > rad_division)
                 binned_super = binned_result[splice_super]
 
                 Unrolled_Cartilage[i, np.int((angle + 180) / 5)] = np.mean(binned_result[:, 2], axis=0)

--- a/tissues/femoral_cartilage.py
+++ b/tissues/femoral_cartilage.py
@@ -129,7 +129,7 @@ class FemoralCartilage(Tissue):
 
             for angle in angles:
                 bottom_bin = angle
-                top_bin = angle + 5
+                top_bin = angle + dtheta
 
                 splice_matrix = np.where((polar_coords[:, 0] > bottom_bin) & (polar_coords[:, 0] <= top_bin))
 

--- a/tissues/femoral_cartilage.py
+++ b/tissues/femoral_cartilage.py
@@ -196,12 +196,20 @@ class FemoralCartilage(Tissue):
                 Unrolled_Cartilage[curr_bin, curr_slice] = np.nanmean(qv_bin)
 
                 qv_superficial = qv_slice[np.logical_and(theta_bins == curr_bin, ds_slice == self.SUPERFICIAL_KEY)]
-                Sup_layer[curr_bin, curr_slice] = np.nanmean(qv_superficial)
-
                 qv_deep = qv_slice[np.logical_and(theta_bins == curr_bin, ds_slice == self.DEEP_KEY)]
+                # assert len(qv_superficial) > 1, "must have at least 1 superficial pixel"
+                # assert len(qv_deep) >
+
+                if len(qv_superficial) <= 1 and np.sum(np.isnan(qv_superficial)) == len(qv_superficial):
+                    import pdb; pdb.set_trace()
+
+                if len(qv_deep) <= 1 and np.sum(np.isnan(qv_deep)) == len(qv_deep):
+                    import pdb; pdb.set_trace()
+
+                Sup_layer[curr_bin, curr_slice] = np.nanmean(qv_superficial)
                 Deep_layer[curr_bin, curr_slice] = np.nanmean(qv_deep)
 
-                assert np.sum(np.isnan(qv_deep)) != len(qv_superficial) or np.sum(np.isnan(qv_superficial)) != len(qv_superficial)
+                assert np.sum(np.isnan(qv_deep)) != len(qv_deep) or np.sum(np.isnan(qv_superficial)) != len(qv_superficial)
 
         Unrolled_Cartilage[Unrolled_Cartilage == 0] = np.nan
         Sup_layer[Sup_layer == 0] = np.nan

--- a/tissues/femoral_cartilage.py
+++ b/tissues/femoral_cartilage.py
@@ -195,13 +195,10 @@ class FemoralCartilage(Tissue):
 
                 Unrolled_Cartilage[curr_bin, curr_slice] = np.nanmean(qv_bin)
 
-                # TODO: check if it should be possible to have deep, but not superficial and vice versa
                 qv_superficial = qv_slice[np.logical_and(theta_bins == curr_bin, ds_slice == self.SUPERFICIAL_KEY)]
-                #assert np.sum(np.isnan(qv_superficial)) != len(qv_superficial)
                 Sup_layer[curr_bin, curr_slice] = np.nanmean(qv_superficial)
 
                 qv_deep = qv_slice[np.logical_and(theta_bins == curr_bin, ds_slice == self.DEEP_KEY)]
-                #assert np.sum(np.isnan(qv_deep)) != len(qv_superficial)
                 Deep_layer[curr_bin, curr_slice] = np.nanmean(qv_deep)
 
                 assert np.sum(np.isnan(qv_deep)) != len(qv_superficial) or np.sum(np.isnan(qv_superficial)) != len(qv_superficial)
@@ -252,7 +249,6 @@ class FemoralCartilage(Tissue):
         pd_header = ['Subject', 'Location', 'Side', 'Region', 'Mean', 'Std', 'Median']
         pd_list = []
 
-        # TODO: identify pixels in deep and superficial that are anterior/central/posterior and medial/lateral
         # Replace strings with values - eg. DMA = 'deep, medial, anterior'
         # tissue_values = [['DMA', 'DMC', 'DMP'], ['DLA', 'DLC', 'DLP'],
         #                  ['SMA', 'SMC', 'SMP'], ['SLA', 'SLC', 'SLP'],

--- a/utils/geometry_utils.py
+++ b/utils/geometry_utils.py
@@ -47,4 +47,7 @@ def cart2pol(x, y):
     rho = np.sqrt(x ** 2 + y ** 2)
     phi = np.arctan2(y, x)
 
-    return (rho, phi)
+    phi = phi * (180 / np.pi)  # degrees
+    phi[phi == 180] = -180
+
+    return rho, phi

--- a/utils/img_utils.py
+++ b/utils/img_utils.py
@@ -4,7 +4,6 @@ import matplotlib
 import numpy as np
 import seaborn as sns
 
-matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
 


### PR DESCRIPTION
### Bug
Femoral cartilage excel spreadsheet average values were incorrectly taking mean of unrolled region.

### Fix 
1. Use unrolled region to generate subdivisions between medial/lateral and anterior/central/posterior. 
2. Project these regions back to 3D mask. 
3. Calculate average quantitative values by taking average from corresponding voxels in 3D quantitative volume

### Potential future fixes
**Anterior/Central/Posterior Division**: Currently, central region is defined as middle 30 degrees of unrolled graph. However, this is not necessarily the case for all subjects. Real implementation should be based on location of meniscus.

### Issues Resolved
resolved #6 