### PR TITLE
Add multiple worker support for loading and fitting

### DIFF
--- a/dosma/scan_sequences/cones.py
+++ b/dosma/scan_sequences/cones.py
@@ -121,7 +121,7 @@ class Cones(NonTargetSequence):
 
         self.subvolumes = subvolumes
 
-    def generate_t2_star_map(self, tissue: Tissue, mask_path: str = None):
+    def generate_t2_star_map(self, tissue: Tissue, mask_path: str = None, num_workers: int = 0):
         """Generate 3D T2-star map and r-squared fit map using mono-exponential fit across subvolumes acquired at
             different echo times.
 
@@ -131,6 +131,8 @@ class Cones(NonTargetSequence):
             tissue (Tissue): Tissue to generate quantitative value for.
             mask_path (:obj:`str`, optional): File path to mask of ROI to analyze. If specified, only voxels specified
                 by mask will be fit. Speeds up computation. Defaults to `None`.
+            num_workers (int, optional): Number of subprocesses to use for fitting.
+                If `0`, will execute on the main thread.
 
         Returns:
             qv.T2Star: T2-star fit for tissue.
@@ -152,12 +154,14 @@ class Cones(NonTargetSequence):
             spin_lock_times.append(echo_time)
             subvolumes_list.append(self.subvolumes[echo_time])
 
-        mef = MonoExponentialFit(spin_lock_times,
-                                 subvolumes_list,
-                                 mask=mask,
-                                 bounds=(__T2_STAR_LOWER_BOUND__, __T2_STAR_UPPER_BOUND__),
-                                 tc0=__INITIAL_T2_STAR_VAL__,
-                                 decimal_precision=__T2_STAR_DECIMAL_PRECISION__)
+        mef = MonoExponentialFit(
+            spin_lock_times, subvolumes_list,
+            mask=mask,
+            bounds=(__T2_STAR_LOWER_BOUND__, __T2_STAR_UPPER_BOUND__),
+            tc0=__INITIAL_T2_STAR_VAL__,
+            decimal_precision=__T2_STAR_DECIMAL_PRECISION__,
+            num_workers=num_workers,
+        )
 
         t2star_map, r2 = mef.fit()
 

--- a/dosma/scan_sequences/cube_quant.py
+++ b/dosma/scan_sequences/cube_quant.py
@@ -99,7 +99,8 @@ class CubeQuant(NonTargetSequence):
             tissue (Tissue): Tissue to generate quantitative value for.
             mask_path (:obj:`str`, optional): File path to mask of ROI to analyze. If specified, only voxels specified
                 by mask will be fit. Speeds up computation. Defaults to `None`.
-            num_workers (int, optional): Number of workers for fitting.
+            num_workers (int, optional): Number of subprocesses to use for fitting.
+                If `0`, will execute on the main thread.
 
         Returns:
             qv.T1Rho: T1-rho fit for tissue.

--- a/dosma/utils/fits.py
+++ b/dosma/utils/fits.py
@@ -1,8 +1,13 @@
+import inspect
+import multiprocessing as mp
 import warnings
 from abc import ABC, abstractmethod
+from functools import partial
 
 import numpy as np
 from scipy import optimize as sop
+from tqdm import tqdm
+from tqdm.contrib.concurrent import process_map
 
 from dosma import defaults
 from dosma.data_io.med_volume import MedicalVolume
@@ -44,8 +49,11 @@ class MonoExponentialFit(_Fit):
         decimal_precision (:obj:`int`, optional): Rounding precision after the decimal point. Defaults to `1`.
     """
 
-    def __init__(self, ts: Sequence[float], subvolumes: List[MedicalVolume], mask: MedicalVolume = None,
-                 bounds: Tuple[float] = (0, 100.0), tc0: float = 30.0, decimal_precision: int = 1):
+    def __init__(
+        self, ts: Sequence[float], subvolumes: List[MedicalVolume], mask: MedicalVolume = None,
+        bounds: Tuple[float] = (0, 100.0), tc0: float = 30.0, decimal_precision: int = 1, verbose: bool = False,
+        num_workers: int = 0,
+    ):
 
         if (not isinstance(subvolumes, list)) or (not all([isinstance(sv, MedicalVolume) for sv in subvolumes])):
             raise TypeError("`subvolumes` must be list of MedicalVolumes.")
@@ -59,6 +67,8 @@ class MonoExponentialFit(_Fit):
         if mask and not isinstance(mask, MedicalVolume):
             raise TypeError("`mask` must be a MedicalVolume")
         self.mask = mask
+        self.verbose = verbose
+        self.num_workers = num_workers
 
         orientation = self.subvolumes[0].orientation
         for sv in self.subvolumes[1:]:
@@ -102,7 +112,12 @@ class MonoExponentialFit(_Fit):
 
         svs = np.concatenate(svs)
 
-        vals, r_squared = __fit_monoexp_tc__(self.ts, svs, self.tc0)
+        p0 = (1.0, -1 / self.tc0)
+        popt, r_squared = curve_fit(
+            monoexponential, self.ts, svs, self.bounds, p0=p0, 
+            show_pbar=self.verbose, num_workers=self.num_workers,
+        )
+        vals = 1 / np.abs(popt[:, 1])
 
         map_unfiltered = vals.reshape(original_shape)
         r_squared = r_squared.reshape(original_shape)
@@ -111,7 +126,7 @@ class MonoExponentialFit(_Fit):
         tc_map = map_unfiltered * (r_squared >= preferences.fitting_r2_threshold)
 
         # Filter calculated values that are below limit bounds.
-        tc_map[tc_map <= self.bounds[0]] = np.nan
+        tc_map[tc_map < self.bounds[0]] = np.nan
         tc_map = np.nan_to_num(tc_map)
         tc_map[tc_map > self.bounds[1]] = np.nan
         tc_map = np.nan_to_num(tc_map)
@@ -126,11 +141,128 @@ class MonoExponentialFit(_Fit):
 
 __EPSILON__ = 1e-8
 
+def curve_fit(
+    func, x, y, y_bounds=None, p0=None, maxfev=100, 
+    ftol=1e-5, eps=1e-8, show_pbar=False, num_workers=0, 
+    **kwargs,
+):
+    """
+    Args:
+        func (callable): The model function, f(x, ...). It must take the independent variable 
+            as the first argument and the parameters to fit as separate remaining arguments.
+        x (ndarray): The independent variable(s) where the data is measured. 
+            Should usually be an M-length sequence or an (k,M)-shaped array for functions 
+            with k predictors, but can actually be any object.
+        y (ndarray): The dependent data, a length M array - nominally func(xdata, ...) - or
+            an (M,N)-shaped array for N different sequences.
+        y_bounds (tuple, optional): Lower and upper bound on y values. Defaults to no bounds.
+            Sequences with observations out of this range will not be processed.
+        p0 (Sequence, optional): Initial guess for the parameters (length N). If None, then 
+            the initial values will all be 1 (if the number of parameters for the 
+            function can be determined using introspection, otherwise a ValueError is raised).
+        maxfev (int, optional): Maximum number of function evaluations before the termination.
+            If `bounds` argument for `scipy.optimize.curve_fit` is specified, this corresponds
+            to the `max_nfev` in the least squares algorithm
+        ftol (float): Tolerance for termination by the change of the cost function. 
+            See `scipy.optimize.least_squares` for more details.
+        eps (float, optional): Epsilon for computing r-squared.
+        show_pbar (bool, optional): If `True`, show progress bar. Note this can increase runtime
+            slightly when using multiple workers.
+        kwargs: Keyword args for `scipy.optimize.curve_fit`.
+    """
+    x = np.asarray(x)
+    y = np.asarray(y)
+    if y.ndim == 1:
+        y = y.view(y.shape + (1,))
+    N = y.shape[-1]
+
+    func_args = inspect.getargspec(func).args
+    nparams = len(func_args) - 2 if "self" in func_args else len(func_args) - 1
+    
+    if "bounds" not in kwargs:
+        kwargs["maxfev"] = maxfev
+    elif "max_nfev" not in kwargs:
+        kwargs["max_nfev"] = maxfev
+    
+    num_workers = min(num_workers, N)
+    fitter = partial(
+        _curve_fit, x=x, func=func, y_bounds=y_bounds, p0=p0, 
+        ftol=ftol, eps=eps, show_pbar=show_pbar, nparams=nparams, **kwargs,
+    )
+
+    oob = y_bounds is not None and ((y < y_bounds[0]).any() or (y > y_bounds[1]).any())
+    if oob:
+        warnings.warn("Out of bounds values found. Failure in fit will result in np.nan")
+
+    popts = []
+    r_squared = []
+    if not num_workers:
+        for i in tqdm(range(N), disable=not show_pbar):
+            popt_, r2_ = fitter(y[:, i])
+            popts.append(popt_)
+            r_squared.append(r2_)
+    else:
+        if show_pbar:
+            data = process_map(fitter, y.T, max_workers=num_workers, tqdm_class=tqdm)
+        else:
+            with mp.Pool(num_workers) as p:
+                data = p.map(fitter, y.T)
+        popts, r_squared = [x[0] for x in data], [x[1] for x in data]
+    
+    return np.stack(popts, axis=0), np.asarray(r_squared)
+
+
+def _curve_fit(
+    y, x, func, y_bounds=None, p0=None, 
+    maxfev=100, ftol=1e-5, eps=1e-8, 
+    show_pbar=False, nparams=None, **kwargs
+):
+    def _fit_internal(_x, _y):
+        popt, _ = sop.curve_fit(func, _x, _y, p0=p0, maxfev=maxfev, ftol=ftol, **kwargs)
+
+        residuals = _y - func(_x, *popt)
+        ss_res = np.sum(residuals ** 2)
+        ss_tot = np.sum((_y - np.mean(_y)) ** 2)
+        r_squared = 1 - (ss_res / (ss_tot + eps))
+
+        return popt, r_squared
+    
+    if nparams is None:
+        func_args = inspect.getargspec(func).args
+        nparams = len(func_args) - 2 if "self" in func_args else len(func_args) - 1
+
+    # import pdb; pdb.set_trace()
+    oob = y_bounds is not None and ((y < y_bounds[0]).any() or (y > y_bounds[1]).any())
+    if oob or (y == 0).all():
+        return (np.nan,) * nparams, 0
+
+    try:
+        popt_, r2_ = _fit_internal(x, y)
+    except RuntimeError:
+        popt_, r2_ = (np.nan,) * nparams, 0
+    return popt_, r2_
+
+
+def monoexponential(x, a, b):
+    """Function: :math:`f(x) = a * e^{b*x}`."""
+    return a * np.exp(b * x)
+
+
+def biexponential(x, a1, b1, a2, b2):
+    """Function: :math:`f(x) = a1*e^{b1*x} + a2*e^{b2*x}`."""
+    return a1 * np.exp(b1 * x) + a2 * np.exp(b2 * x)
+
 
 def __fit_mono_exp__(x, y, p0=None):
     def func(t, a, b):
         exp = np.exp(b * t)
         return a * exp
+
+    warnings.warn(
+        "__fit_mono_exp__ is deprecated since v0.12 and will no longer be "
+        "supported in v0.13. Use `curve_fit` instead.",
+        DeprecationWarning
+    )
 
     x = np.asarray(x)
     y = np.asarray(y)
@@ -146,13 +278,19 @@ def __fit_mono_exp__(x, y, p0=None):
     return popt, r_squared
 
 
-def __fit_monoexp_tc__(x, ys, tc0):
+def __fit_monoexp_tc__(x, ys, tc0, show_pbar=False):
+    warnings.warn(
+        "__fit_monoexp_tc__ is deprecated since v0.12 and will no longer be "
+        "supported in v0.13. Use `curve_fit` instead.",
+        DeprecationWarning
+    )
+
     p0 = (1.0, -1 / tc0)
     time_constants = np.zeros([1, ys.shape[-1]])
     r_squared = np.zeros([1, ys.shape[-1]])
 
     warned_negative = False
-    for i in range(ys.shape[1]):
+    for i in tqdm(range(ys.shape[1]), disable=not show_pbar):
         y = ys[..., i]
         if (y < 0).any() and not warned_negative:
             warned_negative = True

--- a/environment.yml
+++ b/environment.yml
@@ -34,3 +34,4 @@ dependencies:
   - tensorflow==1.8.0
   - openpyxl==2.5.8
   - Pmw==2.0.1
+  - tqdm>=4.42.0

--- a/environment.yml
+++ b/environment.yml
@@ -18,13 +18,13 @@ dependencies:
   - keras==2.1.6
   - natsort==5.3.3
   - nested-lookup>=0.2.17
-  - nibabel==2.3.0
+  - nibabel>=2.3.0
   - nipy==0.4.2
   - nipype==1.1.2
   - opencv-python==3.4.2.17
   - pandas==0.23.4
   - py==1.6.0
-  - pydicom==1.1.0
+  - pydicom==2.0.0
   - pydot==1.2.4
   - pytest==3.8.0
   - scikit-image==0.13.1

--- a/setup.py
+++ b/setup.py
@@ -60,5 +60,6 @@ setup(
         "seaborn",
         "openpyxl",
         "Pmw",
+        "tqdm>=4.42.0"
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         "nipype",
         "opencv-python",
         "pandas",
-        "pydicom",
+        "pydicom==2.0.0",
         "scikit-image",
         "scipy",
         "seaborn",

--- a/tests/scan_sequences/test_cones.py
+++ b/tests/scan_sequences/test_cones.py
@@ -34,13 +34,13 @@ class ConesTest(util.ScanTest):
 
         # run analysis with femoral cartilage, without mask in tissue, but mask as additional input.
         tissue = FemoralCartilage()
-        map1 = scan.generate_t2_star_map(tissue, TARGET_MASK_PATH)
+        map1 = scan.generate_t2_star_map(tissue, TARGET_MASK_PATH, num_workers=util.num_workers())
         assert map1 is not None, "map should not be None"
 
         # add mask to femoral cartilage and run
         nr = NiftiReader()
         tissue.set_mask(nr.load(TARGET_MASK_PATH))
-        map2 = scan.generate_t2_star_map(tissue)
+        map2 = scan.generate_t2_star_map(tissue, num_workers=util.num_workers())
         assert map2 is not None, "map should not be None"
 
         # map1 and map2 should be identical

--- a/tests/scan_sequences/test_cubequant.py
+++ b/tests/scan_sequences/test_cubequant.py
@@ -32,13 +32,13 @@ class CubeQuantTest(util.ScanTest):
 
         # run analysis with femoral cartilage, without mask
         tissue = FemoralCartilage()
-        map1 = scan.generate_t1_rho_map(tissue, TARGET_MASK_PATH)
+        map1 = scan.generate_t1_rho_map(tissue, TARGET_MASK_PATH, num_workers=util.num_workers())
         assert map1 is not None, "map should not be None"
 
         # add mask to femoral cartilage and run
         nr = NiftiReader()
         tissue.set_mask(nr.load(TARGET_MASK_PATH))
-        map2 = scan.generate_t1_rho_map(tissue)
+        map2 = scan.generate_t1_rho_map(tissue, num_workers=util.num_workers())
         assert map2 is not None, "map should not be None"
 
         # map1 and map2 should be identical

--- a/tests/scan_sequences/test_mapss.py
+++ b/tests/scan_sequences/test_mapss.py
@@ -47,7 +47,7 @@ class MapssTest(util.ScanTest):
 
             nr = NiftiReader()
             tissue.set_mask(nr.load(MANUAL_SEGMENTATION_MASK_PATH))
-            map2 = action(tissue)
+            map2 = action(tissue, num_workers=util.num_workers())
             assert map2 is not None, "%s: map2 should not be None" % str(action)
 
             # map1 and map2 should be identical

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -64,6 +64,11 @@ class TestDicomIO(unittest.TestCase):
         :param h2:
         :return:
         """
+        # try:
+        #     str(h1), str(h2)
+        # except:
+        #     return True
+
         rep = []
         for dataset in (h1, h2):
             lines = str(dataset).split("\n")
@@ -192,8 +197,8 @@ class TestDicomIO(unittest.TestCase):
             volumes = self.dr.load(dicom_path)
 
             # Reorient images
-            o = volumes[
-                0].orientation  # echo 1 and echo 2 have the same orientation, because loaded from the total dicom path
+            # echo 1 and echo 2 have the same orientation, because loaded from the total dicom path
+            o = volumes[0].orientation
 
             # generate random permutations of orientations
             orientations = []
@@ -240,6 +245,42 @@ class TestDicomIO(unittest.TestCase):
                     h2 = e_vol.headers[i]
 
                     assert self.are_equivalent_headers(h1, h2), "headers for echoes %d must be equivalent" % echo_num
+    
+    def test_read_multiple_workers(self):
+        """Test reading/writing from multiple workers."""
+        for dp_ind, dp in enumerate(ututils.SCAN_DIRPATHS):
+            curr_scan = ututils.SCANS[dp_ind]
+            curr_scan_info = ututils.SCANS_INFO[curr_scan]
+
+            dicom_path = ututils.get_dicoms_path(dp)
+            volumes_exp = self.dr.load(dicom_path)
+            volumes = DicomReader(num_workers=4).load(dicom_path)
+            assert len(volumes_exp) == len(volumes)
+
+            for vol, exp in zip(volumes, volumes_exp):
+                assert vol.is_identical(exp)
+    
+    def test_write_multiple_workers(self):
+        """Test reading/writing from multiple workers."""
+        for dp_ind, dp in enumerate(ututils.SCAN_DIRPATHS):
+            curr_scan = ututils.SCANS[dp_ind]
+            curr_scan_info = ututils.SCANS_INFO[curr_scan]
+
+            dicom_path = ututils.get_dicoms_path(dp)
+            write_path = ututils.get_write_path(dp, self.data_format)
+            volumes = self.dr.load(dicom_path)
+
+            for ind, vol in enumerate(volumes):
+                exp_path = os.path.join(write_path, 'expected', 'e%d' % (ind + 1))
+                out_path = os.path.join(write_path, 'out', 'e%d' % (ind + 1))
+
+                self.dw.save(vol, exp_path)
+                dw = DicomWriter(num_workers=4).save(vol, out_path)
+
+                expected = self.dr.load(exp_path)[0]
+                out = self.dr.load(out_path)[0]
+
+                assert out.is_identical(expected)
 
 
 class TestInterIO(unittest.TestCase):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -254,7 +254,7 @@ class TestDicomIO(unittest.TestCase):
 
             dicom_path = ututils.get_dicoms_path(dp)
             volumes_exp = self.dr.load(dicom_path)
-            volumes = DicomReader(num_workers=4).load(dicom_path)
+            volumes = DicomReader(num_workers=ututils.num_workers()).load(dicom_path)
             assert len(volumes_exp) == len(volumes)
 
             for vol, exp in zip(volumes, volumes_exp):
@@ -275,7 +275,7 @@ class TestDicomIO(unittest.TestCase):
                 out_path = os.path.join(write_path, 'out', 'e%d' % (ind + 1))
 
                 self.dw.save(vol, exp_path)
-                dw = DicomWriter(num_workers=4).save(vol, out_path)
+                DicomWriter(num_workers=ututils.num_workers()).save(vol, out_path)
 
                 expected = self.dr.load(exp_path)[0]
                 out = self.dr.load(out_path)[0]

--- a/tests/util.py
+++ b/tests/util.py
@@ -58,6 +58,10 @@ def get_expected_data_path(fp):
     return os.path.join(fp, 'expected')
 
 
+def num_workers() -> int:
+    return min(8, os.cpu_count())
+
+
 class ScanTest(unittest.TestCase):
     from dosma.scan_sequences.scans import ScanSequence
     SCAN_TYPE = ScanSequence  # override in subclasses

--- a/tests/utils/test_fitting.py
+++ b/tests/utils/test_fitting.py
@@ -1,0 +1,21 @@
+import unittest
+import numpy as np
+from dosma.utils.fits import curve_fit, monoexponential
+
+from .. import util
+
+
+class TestCurveFit(unittest.TestCase):
+    def test_multiple_workers(self):
+        x = np.asarray([1, 2, 3, 4])
+        ys = np.stack(
+            [monoexponential(x, np.random.random(), np.random.random()) for _ in range(1000)],
+            axis=-1
+        )
+        popt, _ = curve_fit(monoexponential, x, ys)
+        popt_mw, _ = curve_fit(monoexponential, x, ys, num_workers=util.num_workers())
+        assert np.allclose(popt, popt_mw)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Multiprocessing can be useful to speed up loading time and computation.

### Features
- Added multiple worker support for DICOM reading/writing
- Added multiple worker support for quantitative fitting
- Added `dosma.utils.fits.curve_fit`, a general function using `scipy.optimize.curve_fit` for multi-worker data fitting

### Changes
- Added `num_workers` argument to `DicomWriter` and `DicomReader`
- Refactor `MonoExponentialFit` to support multiple workers
- `dosma.utils.fits.curve_fit` added and deprecated `__fit_monoexp_tc__` and `__fit_mono_exp__`