### PR TITLE
Update patellar/tibial cartilage deep/superficial subdivision to 1D column-wise

### DIFF
--- a/dosma/tissues/femoral_cartilage.py
+++ b/dosma/tissues/femoral_cartilage.py
@@ -15,7 +15,7 @@ import numpy as np
 import pandas as pd
 import scipy.ndimage as sni
 
-from dosma.tissues.tissue import Tissue
+from dosma.tissues.tissue import Tissue, largest_cc
 
 from dosma.data_io.format_io import ImageDataFormat
 from dosma.data_io.med_volume import MedicalVolume
@@ -362,7 +362,7 @@ class FemoralCartilage(Tissue):
         Args:
             mask (MedicalVolume): Binary mask of segmented tissue.
         """
-        msk = np.asarray(_largest_cc(mask.volume), dtype=np.uint8)
+        msk = np.asarray(largest_cc(mask.volume), dtype=np.uint8)
         mask_copy = deepcopy(mask)
         mask_copy.volume = msk
 
@@ -482,30 +482,3 @@ class FemoralCartilage(Tissue):
         ml_division_unrolled[np.isnan(unrolled_total)] = np.nan
 
         return acp_division_unrolled, ml_division_unrolled
-
-
-def _largest_cc(mask):
-    """ Return the largest connected component of a 3D mask array.
-    Parameters
-    -----------
-    mask: 3D boolean array
-          3D array indicating a mask.
-    Returns
-    --------
-    mask: 3D boolean array
-          3D array indicating a mask, with only one connected component.
-
-    Adapted from nipy (https://github.com/nipy/nipy/blob/master/nipy/labs/mask.py)
-    due to dependency issues.
-    """
-    # We use asarray to be able to work with masked arrays.
-    mask = np.asarray(mask)
-    labels, label_nb = sni.label(mask)
-    if not label_nb:
-        raise ValueError('No non-zero values: no connected components')
-    if label_nb == 1:
-        return mask.astype(np.bool)
-    label_count = np.bincount(labels.ravel().astype(np.int))
-    # discard 0 the 0 label
-    label_count[0] = 0
-    return labels == label_count.argmax()

--- a/dosma/tissues/patellar_cartilage.py
+++ b/dosma/tissues/patellar_cartilage.py
@@ -81,33 +81,41 @@ class PatellarCartilage(Tissue):
         return total, superficial, deep
 
     def split_regions(self, base_map):
-        """Split patellar cartilage into deep/superficial regions"""
+        """Split patellar cartilage into deep/superficial regions.
+
+        For patellar cartilage, the superficial/deep transition occurs in
+        the anterior/posterior (A/P) direction. The boundary is determined
+        for each non-zero 1D column spanning independently by the local
+        center-of-mass (COM).
+        
+        Args:
+            base_map (ndarray): Binary 3D mask with orientation (SI, AP, ML/LM).
+                If `self.medial_to_lateral`, last dimension should be ML.
+        """
         if np.sum(base_map) == 0:
             warnings.warn('No mask for `%s` was found.' % self.FULL_NAME)
 
         self.regions_mask = self.__2d_split_regions(base_map)
 
     def __2d_split_regions(self, base_map):
-        """Split patellar cartilage into deep/superficial regions per sagittal slice
+        """Split patellar cartilage into deep/superficial regions.
 
-        Left = Superficial, Right = deep
-        For patellar cartilage, the superficial-->deep transition happens in the anterior-->posterior direction
+        Args:
+            base_map (ndarray): Binary 3D mask with orientation (SI, AP, ML/LM).
+                If `self.medial_to_lateral`, last dimension should be ML.
 
         TODO (arjundd): refactor to make region map a Medical Volume
         """
-        region_mask_sup_deep = np.zeros(base_map.shape)
-
-        for s in range(base_map.shape[-1]):
-            c_slice = base_map[..., s]
-            if np.sum(c_slice) == 0:
-                ds_split = 0
-            else:
-                center_of_mass = sni.measurements.center_of_mass(c_slice)
-                ds_split = int(center_of_mass[1])
-            com_deep_superficial = ds_split
-            region_mask_sup_deep[:, :com_deep_superficial, s] = self._REGION_SUPERFICIAL_KEY
-            region_mask_sup_deep[:, com_deep_superficial:, s] = self._REGION_DEEP_KEY
-
+        locs = base_map.sum(axis=1).nonzero()
+        voxels = base_map[locs[0], :, locs[1]]
+        com_sup_inf = np.asarray([
+            int(np.ceil(sni.measurements.center_of_mass(voxels[i, :])[0]))
+            for i in range(voxels.shape[0])
+        ])
+        region_mask_sup_deep = np.full(base_map.shape, self._REGION_DEEP_KEY)
+        for i in range(len(com_sup_inf)):
+            region_mask_sup_deep[locs[0][i], :com_sup_inf[i], locs[1][i]] = self._REGION_SUPERFICIAL_KEY
+        
         return region_mask_sup_deep[..., np.newaxis]
 
     def __calc_quant_vals__(self, quant_map, map_type):

--- a/dosma/tissues/patellar_cartilage.py
+++ b/dosma/tissues/patellar_cartilage.py
@@ -4,6 +4,7 @@ Attributes:
     BOUNDS (dict): Upper bounds for quantitative values.
 """
 import os
+import itertools
 import warnings
 from copy import deepcopy
 
@@ -12,7 +13,7 @@ import numpy as np
 import pandas as pd
 import scipy.ndimage as sni
 
-from dosma.tissues.tissue import Tissue
+from dosma.tissues.tissue import Tissue, largest_cc
 
 from dosma.defaults import preferences
 from dosma.utils import io_utils
@@ -86,7 +87,8 @@ class PatellarCartilage(Tissue):
         For patellar cartilage, the superficial/deep transition occurs in
         the anterior/posterior (A/P) direction. The boundary is determined
         for each non-zero 1D column spanning independently by the local
-        center-of-mass (COM).
+        center-of-mass (COM). The medial/lateral (M/L) plane is computed
+        using the global COM.
         
         Args:
             base_map (ndarray): Binary 3D mask with orientation (SI, AP, ML/LM).
@@ -95,17 +97,7 @@ class PatellarCartilage(Tissue):
         if np.sum(base_map) == 0:
             warnings.warn('No mask for `%s` was found.' % self.FULL_NAME)
 
-        self.regions_mask = self.__2d_split_regions(base_map)
-
-    def __2d_split_regions(self, base_map):
-        """Split patellar cartilage into deep/superficial regions.
-
-        Args:
-            base_map (ndarray): Binary 3D mask with orientation (SI, AP, ML/LM).
-                If `self.medial_to_lateral`, last dimension should be ML.
-
-        TODO (arjundd): refactor to make region map a Medical Volume
-        """
+        # Superficial/Deep (A/P)
         locs = base_map.sum(axis=1).nonzero()
         voxels = base_map[locs[0], :, locs[1]]
         com_sup_inf = np.asarray([
@@ -115,8 +107,16 @@ class PatellarCartilage(Tissue):
         region_mask_sup_deep = np.full(base_map.shape, self._REGION_DEEP_KEY)
         for i in range(len(com_sup_inf)):
             region_mask_sup_deep[locs[0][i], :com_sup_inf[i], locs[1][i]] = self._REGION_SUPERFICIAL_KEY
-        
-        return region_mask_sup_deep[..., np.newaxis]
+
+        # M/L
+        cum_ml = np.nonzero(base_map.sum(axis=(0,1)))[0]
+        # midpoint_ml = int(np.ceil((np.min(cum_ml) + np.max(cum_ml)) / 2))
+        midpoint_ml = int(np.ceil(sni.measurements.center_of_mass(base_map)[2]))
+        region_mask_med_lat = np.full(base_map.shape, self._LATERAL_KEY)
+        medial_span = slice(0, midpoint_ml) if self.medial_to_lateral else slice(midpoint_ml, None)
+        region_mask_med_lat[:, :, medial_span] = self._MEDIAL_KEY
+
+        self.regions_mask = np.stack([region_mask_sup_deep, region_mask_med_lat], axis=-1)
 
     def __calc_quant_vals__(self, quant_map, map_type):
         subject_pid = self.pid
@@ -130,13 +130,19 @@ class PatellarCartilage(Tissue):
         quant_map_volume = mask * quant_map_volume
 
         deep_superficial_map = self.regions_mask[..., 0]
+        med_lat_map = self.regions_mask[..., 1]
 
         axial_names = ['superficial', 'deep', 'total']
+        sagittal_names = ['medial', 'lateral']
 
-        pd_header = ['Subject', 'Location', 'Mean', 'Std', 'Median']
+        pd_header = ['Subject', 'Location', 'Condyle', 'Mean', 'Std', 'Median']
         pd_list = []
 
-        for axial in [self._REGION_SUPERFICIAL_KEY, self._REGION_DEEP_KEY, self._TOTAL_AXIAL_KEY]:
+        regions = itertools.product(
+            [self._REGION_SUPERFICIAL_KEY, self._REGION_DEEP_KEY, self._TOTAL_AXIAL_KEY],
+            [self._MEDIAL_KEY, self._LATERAL_KEY],
+        )
+        for axial, sagittal in regions:
             if axial == self._TOTAL_AXIAL_KEY:
                 axial_map = np.asarray(deep_superficial_map == self._REGION_SUPERFICIAL_KEY, dtype=np.float32) + \
                             np.asarray(deep_superficial_map == self._REGION_DEEP_KEY, dtype=np.float32)
@@ -144,7 +150,9 @@ class PatellarCartilage(Tissue):
             else:
                 axial_map = deep_superficial_map == axial
 
-            curr_region_mask = quant_map_volume * axial_map
+            sagittal_map = med_lat_map == sagittal
+
+            curr_region_mask = quant_map_volume * axial_map * sagittal_map
             curr_region_mask[curr_region_mask == 0] = np.nan
 
             # discard all values that are 0
@@ -152,7 +160,7 @@ class PatellarCartilage(Tissue):
             c_std = np.nanstd(curr_region_mask)
             c_median = np.nanmedian(curr_region_mask)
 
-            row_info = [subject_pid, axial_names[axial], c_mean, c_std, c_median]
+            row_info = [subject_pid, axial_names[axial], sagittal_names[sagittal], c_mean, c_std, c_median]
 
             pd_list.append(row_info)
 
@@ -171,7 +179,10 @@ class PatellarCartilage(Tissue):
         self.__store_quant_vals__(maps, df, map_type)
 
     def set_mask(self, mask):
+        msk = np.asarray(largest_cc(mask.volume), dtype=np.uint8)
         mask_copy = deepcopy(mask)
+        mask_copy.volume = msk
+
         super().set_mask(mask_copy)
 
         self.split_regions(self.__mask__.volume)

--- a/tests/tissues/test_tissue.py
+++ b/tests/tissues/test_tissue.py
@@ -1,0 +1,30 @@
+import unittest
+import numpy as np
+
+from dosma.tissues.tissue import largest_cc
+
+
+class TestLargestCC(unittest.TestCase):
+    def test_largest_cc(self):
+        # smallest cc
+        a = np.zeros((100,100)).astype(np.uint8)
+        a[:10, :10] = 1
+
+        # medium cc
+        b = np.zeros((100,100)).astype(np.uint8)
+        b[85:, 85:] = 1
+
+        # largest cc
+        c = np.zeros((100, 100)).astype(np.uint8)
+        c[25:75, 25:75] = 1
+
+        mask = a | b | c
+
+        assert np.all(largest_cc(mask) == c)  # only largest cc returned
+        assert np.all(largest_cc(mask, num=2) == (b | c))  # largest 2 cc
+        assert np.all(largest_cc(mask, num=3) == (a | b | c))  # largest 3 cc
+        assert np.all(largest_cc(mask, num=4) == (a | b | c))  # only 3 cc, return all
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Tibial/patellar cartilage deep/superficial division was previously done using global center-of-mass (COM) measures. However, this method is uniquely susceptible to alignment issues, particularly in tibial cartilage where the lateral plateau is more elevated than the medial plateau. These differences are detailed below

### Tibial Cartilage
#### Updates
1. 1D column-wise deep/superficial division
2. Anterior/Central/Posterior subdivision

#### Description
Previously, tibial cartilage subdivisions were very asymmetric in the deep/superficial dimension as shown by the image below. Note b/c on color palette limitations, some colors are repeated for different regions. Regions (abbreviations) are superior (Sup), inferior (Inf), anterior (Ant), posterior (Pos). Note medial/lateral are not specified but are part of the existing subdivision.

![image](https://user-images.githubusercontent.com/12801331/102672720-787e6e80-4146-11eb-815b-baffb271d6d4.png)

We solved this issue by finding the COM of each column in the superior/inferior (S/I) direction independently. While this slightly increases runtime, the increase is relatively negligible for a 512x512x160 volume. We also added a central region (Cen) to the A/P subdivision by dividing each plateau into thirds along the A/P direction.

![image](https://user-images.githubusercontent.com/12801331/102672678-4ff67480-4146-11eb-80fc-9421754b4884.png)

### Patellar Cartilage
#### Updates
1. 1D column-wise deep/superficial division
2. Medial/Lateral subdivision

#### Description
Like tibial cartilage, deep/superficial divisions are now done by finding the local COM of 1D columns. These columns span the A/P direction. We also added medial/lateral subdivisions

![image](https://user-images.githubusercontent.com/12801331/102681922-3e2ec480-417a-11eb-9a3b-69c0c5cc3d07.png)
