### PR TITLE
Load dicoms from file(s) 

### DIFF
--- a/dosma/data_io/dicom_io.py
+++ b/dosma/data_io/dicom_io.py
@@ -17,6 +17,7 @@ import functools
 import multiprocessing as mp
 import os
 from math import log10, ceil
+from typing import List, Sequence, Union
 
 import nibabel as nib
 import numpy as np
@@ -29,7 +30,6 @@ from dosma.data_io.med_volume import MedicalVolume
 from dosma.defaults import AFFINE_DECIMAL_PRECISION, SCANNER_ORIGIN_DECIMAL_PRECISION
 from dosma.utils import io_utils
 
-from typing import List, Union
 
 __all__ = ["DicomReader", "DicomWriter"]
 
@@ -163,47 +163,71 @@ class DicomReader(DataReader):
         """
         self.num_workers = num_workers
 
-    def load(self, dicom_dir_path: str, group_by: Union[str, tuple] = 'EchoNumbers', ignore_ext: bool = False):
+    def load(
+        self,
+        path: Union[str, Sequence[str]],
+        group_by: Union[str, tuple] = 'EchoNumbers',
+        ignore_ext: bool = False,
+    ):
         """Load dicoms into `MedicalVolume`s grouped by `group_by` tag.
 
+        When loading files from a directory, all hidden files (files starting with ".")
+        are ignored. Files are sorted in alphabetical order.
+
         Args:
-            dicom_dir_path (str): Path to directory with dicom files.
-            group_by (`str` or `tuple`, optional): DICOM field tag name or tag number used to group dicoms. Defaults
-                to `EchoNumbers`. Most DICOM headers encode different echo numbers as volumes acquired at different echo
+            path (`str(s)`): Directory with dicom files or dicom files.
+            group_by (`str` or `tuple`, optional): DICOM field tag name or tag number
+                used to group dicoms. Defaults to `EchoNumbers`. Most DICOM headers
+                encode different echo numbers as volumes acquired at different echo
                 times or different phases.
-            ignore_ext (`bool`, optional): Ignore extension (`.dcm`) when loading dicoms. Defaults to `False`.
+            ignore_ext (`bool`, optional): If `True`, ignore extension (`.dcm`)
+                when loading dicoms from directory. Defaults to `False`.
 
         Returns:
             list[MedicalVolume]: Different volumes grouped by the `group_by` DICOM tag.
 
         Raises:
-            NotADirectoryError: If `dicom_dir_path` does not exist or is not a directory.
-            FileNotFoundError: If no dicom files found in directory.
+            ValueError: If `group_by` not specified or if single dicom file specified.
+            IOError: If directory or dicom file(s) specified by `path` do not exist.
+            FileNotFoundError: If no valid dicom files found.
 
         Note:
             This function sorts files using natsort, an intelligent sorting tool. Please verify dicoms are labeled in a
                 sequenced manner (e.g.: dicom1,dicom2,dicom3,...).
         """
-        if not os.path.isdir(dicom_dir_path):
-            raise NotADirectoryError("Directory {} does not exist".format(dicom_dir_path))
-
         if not group_by:
             raise ValueError("`group_by` must be specified, even if there are not multiple volumes encoded in dicoms")
 
-        possible_files = os.listdir(dicom_dir_path)
-
-        lstFilesDCM = []
-        for f in possible_files:
-            # If ignore extension, don't look for '.dcm' extension.
-            match_ext = ignore_ext or (not ignore_ext and self.data_format_code.is_filetype(f))
-            is_file = os.path.isfile(os.path.join(dicom_dir_path, f))
-            is_hidden_file = f.startswith('.')
-            if is_file and match_ext and not is_hidden_file:
-                lstFilesDCM.append(os.path.join(dicom_dir_path, f))
+        if isinstance(path, str):
+            if os.path.isdir(path):
+                possible_files = os.listdir(path)
+                lstFilesDCM = []
+                for f in possible_files:
+                    # If ignore extension, don't look for '.dcm' extension.
+                    match_ext = ignore_ext or (
+                        not ignore_ext and self.data_format_code.is_filetype(f)
+                    )
+                    is_file = os.path.isfile(os.path.join(path, f))
+                    is_hidden_file = f.startswith('.')
+                    if is_file and match_ext and not is_hidden_file:
+                        lstFilesDCM.append(os.path.join(path, f))
+            elif os.path.isfile(path):
+                raise ValueError("Single dicom files not currently supported")
+            else:
+                raise IOError(f"No directory or file found - {path}")
+        else:
+            not_files = [x for x in path if not os.path.isfile(x)]
+            if len(not_files) > 0:
+                raise IOError(
+                    "Files not found:\n{}".format(
+                        "".join("\t{}\n".format(x) for x in not_files)
+                    )
+                )
+            lstFilesDCM = path
 
         lstFilesDCM = natsorted(lstFilesDCM)
         if len(lstFilesDCM) == 0:
-            raise FileNotFoundError("No files found in directory {}".format(dicom_dir_path))
+            raise FileNotFoundError("No valid dicom files found in {}".format(path))
 
         # Check if dicom file has the group_by element specified
         temp_dicom = pydicom.read_file(lstFilesDCM[0], force=True)

--- a/dosma/data_io/dicom_io.py
+++ b/dosma/data_io/dicom_io.py
@@ -184,7 +184,7 @@ class DicomReader(DataReader):
         are ignored. Files are sorted in alphabetical order.
 
         Args:
-            path (`str(s)`): Directory with dicom files or dicom files.
+            path (`str(s)`): Directory with dicom files or dicom file(s).
             group_by (`str` or `tuple`, optional): DICOM field tag name or tag number
                 used to group dicoms. Defaults to `EchoNumbers`. Most DICOM headers
                 encode different echo numbers as volumes acquired at different echo

--- a/tests/data_io/test_io.py
+++ b/tests/data_io/test_io.py
@@ -154,6 +154,23 @@ class TestDicomIO(unittest.TestCase):
 
                     assert self.are_equivalent_headers(h1, h2), "headers for echos %d must be equivalent" % echo_number
 
+    def test_dicom_reader_files(self):
+        """Test reading dicoms provided as list of files."""
+        for ind, dp in enumerate(ututils.SCAN_DIRPATHS):
+            curr_scan = ututils.SCANS[ind]
+            multi_echo_read_paths = ututils.get_read_paths(dp, self.data_format)
+            dicom_path = ututils.get_dicoms_path(dp)
+            expected = self.dr.load(dicom_path)
+            volumes = self.dr.load([
+                os.path.join(dicom_path, x) for x in os.listdir(dicom_path)
+                if not x.startswith(".") and x.endswith(".dcm")
+            ])
+
+            assert len(expected) == len(volumes)
+            for v, e in zip(volumes, expected):
+                assert v.is_identical(e)
+                assert all(self.are_equivalent_headers(h1, h2) for h1, h2 in zip(v.headers, e.headers))
+
     def test_dicom_writer(self):
         for dp_ind, dp in enumerate(ututils.SCAN_DIRPATHS):
             curr_scan = ututils.SCANS[dp_ind]

--- a/tests/data_io/test_io.py
+++ b/tests/data_io/test_io.py
@@ -184,6 +184,9 @@ class TestDicomIO(unittest.TestCase):
         expected = pydicom.read_file(dcm_file, force=True)
         vol = self.dr.load(dcm_file)[0]
 
+        assert vol.volume.ndim == 3
+        assert vol.volume.shape == expected.pixel_array.shape + (1,)
+
         spacing_expected = [expected.PixelSpacing[0], expected.PixelSpacing[1], expected.SliceThickness]
         spacing = [np.linalg.norm(vol.affine[:3, i]) for i in range(3)]
         assert np.allclose(spacing, spacing_expected), f"{spacing} == {spacing_expected}"

--- a/tests/data_io/test_io.py
+++ b/tests/data_io/test_io.py
@@ -4,6 +4,8 @@ import re
 import unittest
 
 import difflib
+import numpy as np
+import pydicom
 
 from dosma.data_io.format_io import ImageDataFormat
 from dosma.data_io.dicom_io import DicomReader, DicomWriter
@@ -170,6 +172,21 @@ class TestDicomIO(unittest.TestCase):
             for v, e in zip(volumes, expected):
                 assert v.is_identical(e)
                 assert all(self.are_equivalent_headers(h1, h2) for h1, h2 in zip(v.headers, e.headers))
+
+    def test_dicom_reader_single_file(self):
+        """Test reading single dicom file."""
+        dp = ututils.SCAN_DIRPATHS[0]
+        dicom_path = ututils.get_read_paths(dp, self.data_format)[0]
+        dcm_file = random.choice([
+            os.path.join(dicom_path, x) for x in os.listdir(dicom_path)
+            if not x.startswith(".") and x.endswith(".dcm")
+        ])
+        expected = pydicom.read_file(dcm_file, force=True)
+        vol = self.dr.load(dcm_file)[0]
+
+        spacing_expected = [expected.PixelSpacing[0], expected.PixelSpacing[1], expected.SliceThickness]
+        spacing = [np.linalg.norm(vol.affine[:3, i]) for i in range(3)]
+        assert np.allclose(spacing, spacing_expected), f"{spacing} == {spacing_expected}"
 
     def test_dicom_writer(self):
         for dp_ind, dp in enumerate(ututils.SCAN_DIRPATHS):


### PR DESCRIPTION
Modify `DicomReader.load` to take in directory or file(s). If a single file is specified, the 2D slice is treated as a 3D volume with an expanded dimension such that there are 3 spatial dimensions. The k-direction vector in the affine matrix is determined from the cross product of the i/j-direction vectors and scaled such that the norm is equivalent to `SliceThickness`