### PR TITLE
Add math and boolean logic to MedicalVolume

### DIFF
--- a/dosma/data_io/med_volume.py
+++ b/dosma/data_io/med_volume.py
@@ -28,8 +28,9 @@ class MedicalVolume(object):
     metadata, such as pixel/voxel spacing, global coordinates, rotation information, all of
     which can be characterized by an affine matrix following the RAS+ coordinate system.
 
-    Standard math operations (add, subtract, multiply, divide, power) are supported with other
-    ``MedicalVolume`` objects, numpy arrays (following standard broadcasting), and scalars.
+    Standard math and boolean operations are supported with other ``MedicalVolume`` objects,
+    numpy arrays (following standard broadcasting), and scalars. Boolean operations are performed
+    elementwise, resulting in a volume with shape as ``self.volume.shape``.
     If performing operations between ``MedicalVolume`` objects, both objects must have
     the same shape and affine matrix (spacing, direction, and origin). Header information
     is not deep copied when performing these operations to reduce computational and memory
@@ -168,8 +169,8 @@ class MedicalVolume(object):
         Returns:
             bool: `True` if identical, `False` otherwise.
         """
-        if type(mv) != type(self):
-            raise TypeError('type(mv) must be %s' % str(type(self)))
+        if not isinstance(mv, MedicalVolume):
+            raise TypeError("`mv` must be a MedicalVolume.")
 
         return self.is_same_dimensions(mv) and (mv.volume == self.volume).all()
 
@@ -497,3 +498,45 @@ class MedicalVolume(object):
             other = other.volume
         self._volume.__itruediv__(other)
         return self
+
+    def __ne__(self, other):
+        if isinstance(other, MedicalVolume):
+            assert self.is_same_dimensions(other, err=True)
+            other = other.volume
+        volume = (self._volume != other).astype(np.uint8)
+        return self._partial_clone(volume=volume)
+
+    def __eq__(self, other):
+        if isinstance(other, MedicalVolume):
+            assert self.is_same_dimensions(other, err=True)
+            other = other.volume
+        volume = (self._volume == other).astype(np.uint8)
+        return self._partial_clone(volume=volume)
+
+    def __ge__(self, other):
+        if isinstance(other, MedicalVolume):
+            assert self.is_same_dimensions(other, err=True)
+            other = other.volume
+        volume = (self._volume >= other).astype(np.uint8)
+        return self._partial_clone(volume=volume)
+
+    def __gt__(self, other):
+        if isinstance(other, MedicalVolume):
+            assert self.is_same_dimensions(other, err=True)
+            other = other.volume
+        volume = (self._volume > other).astype(np.uint8)
+        return self._partial_clone(volume=volume)
+
+    def __le__(self, other):
+        if isinstance(other, MedicalVolume):
+            assert self.is_same_dimensions(other, err=True)
+            other = other.volume
+        volume = (self._volume <= other).astype(np.uint8)
+        return self._partial_clone(volume=volume)
+
+    def __lt__(self, other):
+        if isinstance(other, MedicalVolume):
+            assert self.is_same_dimensions(other, err=True)
+            other = other.volume
+        volume = (self._volume < other).astype(np.uint8)
+        return self._partial_clone(volume=volume)

--- a/tests/data_io/test_med_volume.py
+++ b/tests/data_io/test_med_volume.py
@@ -20,6 +20,19 @@ class TestMedicalVolume(unittest.TestCase):
         [0., 0., 0., 1.]
     ])  # ('SI', 'AP', 'LR')
 
+    def test_reformat(self):
+        mv = MedicalVolume(np.random.rand(10,20,30), self._AFFINE)
+        new_orientation = tuple(x[::-1] for x in mv.orientation[::-1])
+        mv2 = mv.reformat(new_orientation)
+        assert mv2.orientation == new_orientation
+        assert id(mv) == id(mv2)
+
+    def test_reformat_as(self):
+        mv = MedicalVolume(np.random.rand(10,20,30), self._AFFINE)
+        mv2 = MedicalVolume(np.random.rand(10,20,30), self._AFFINE[:, (0,2,1,3)])
+        mv = mv.reformat_as(mv2)
+        assert mv.orientation == mv2.orientation
+
     def test_clone(self):
         mv = MedicalVolume(np.random.rand(10,20,30), self._AFFINE)
         mv2 = mv.clone()
@@ -59,6 +72,59 @@ class TestMedicalVolume(unittest.TestCase):
         assert np.allclose(mv.affine, expected.affine)
         assert mv.volume.shape == expected.volume.shape
         assert np.all(mv.volume == expected.volume)
+
+    def test_math(self):
+        mv1 = MedicalVolume(np.ones((10,20,30)), self._AFFINE)
+        mv2 = MedicalVolume(2 * np.ones((10,20,30)), self._AFFINE)
+
+        out = mv1 + mv2
+        assert np.all(mv1._volume == 1)
+        assert np.all(mv2._volume == 2)
+        assert np.all(out._volume == 3)
+
+        out = mv1 - mv2
+        assert np.all(mv1._volume == 1)
+        assert np.all(mv2._volume == 2)
+        assert np.all(out._volume == -1)
+
+        out = mv1 * mv2
+        assert np.all(mv1._volume == 1)
+        assert np.all(mv2._volume == 2)
+        assert np.all(out._volume == 2)
+
+        out = mv1 / mv2
+        assert np.all(mv1._volume == 1)
+        assert np.all(mv2._volume == 2)
+        assert np.all(out._volume == 0.5)
+
+        out = mv1 ** mv2
+        assert np.all(mv1._volume == 1)
+        assert np.all(mv2._volume == 2)
+        assert np.all(out._volume == 1)
+
+        out = mv1.clone()
+        out += mv2
+        assert np.all(out._volume == 3)
+
+        out = mv1.clone()
+        out -= mv2
+        assert np.all(out._volume == -1)
+
+        out = mv1.clone()
+        out *= mv2
+        assert np.all(out._volume == 2)
+
+        out = mv1.clone()
+        out /= mv2
+        assert np.all(out._volume == 0.5)
+
+        out = mv1.clone()
+        out **= mv2
+        assert np.all(out._volume == 1)
+
+        mv3 = mv1.clone().reformat(mv1.orientation[::-1])
+        with self.assertRaises(ValueError):
+            mv3 + mv2
 
 
 if __name__ == "__main__":

--- a/tests/data_io/test_med_volume.py
+++ b/tests/data_io/test_med_volume.py
@@ -126,6 +126,17 @@ class TestMedicalVolume(unittest.TestCase):
         with self.assertRaises(ValueError):
             mv3 + mv2
 
+    def test_comparison(self):
+        mv1 = MedicalVolume(np.ones((10,20,30)), self._AFFINE)
+        mv2 = MedicalVolume(2 * np.ones((10,20,30)), self._AFFINE)
+
+        assert np.all((mv1 == mv1.clone()).volume)
+        assert np.all((mv1 != mv2).volume)
+        assert np.all((mv1 < mv2).volume)
+        assert np.all((mv1 <= mv2).volume)
+        assert np.all((mv2 > mv1).volume)
+        assert np.all((mv2 >= mv1).volume)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
``MedicalVolume`` supports the following operations:
  - math: +, -, *, /, **
  - boolean: ==, !=, >, >=, <, <=

`reformat` and `reformat_as` return `self` to allow chaining operations with medical volumes. For example, `mv = mv.reformat(("SI", "AP", "LR")) + 5`