### PR TITLE
Make `MedicalVolume.reformat` inplace optional

### DIFF
--- a/dosma/data_io/dicom_io.py
+++ b/dosma/data_io/dicom_io.py
@@ -333,7 +333,7 @@ class DicomWriter(DataWriter):
         # Store original orientation so we can undo the dicom-specific reformatting.
         original_orientation = volume.orientation
 
-        volume.reformat(orientation)
+        volume = volume.reformat(orientation)
         volume_arr = volume.volume
         assert volume_arr.shape[2] == len(headers), \
             "Dimension mismatch - {:d} slices but {:d} headers".format(volume_arr.shape[-1], len(headers))
@@ -359,7 +359,3 @@ class DicomWriter(DataWriter):
         else:
             for s in tqdm(range(num_slices), disable=not self.verbose):
                 _write_dicom_file(volume_arr[..., s], headers[s], filepaths[s])
-
-        # Reformat image to original orientation (before saving).
-        # We do this, because saving should not affect the existing state of any variable.
-        volume.reformat(original_orientation)

--- a/dosma/gui/ims.py
+++ b/dosma/gui/ims.py
@@ -501,7 +501,7 @@ class PageThree(tk.Frame):
             return
 
         mask = self.load_volume("Load mask")
-        mask.reformat(self.im.orientation)
+        mask.reformat(self.im.orientation, inplace=True)
         try:
             self.__verify_mask_size(self.im.volume, mask.volume)
         except Exception as e:
@@ -520,11 +520,11 @@ class PageThree(tk.Frame):
 
     def im_update(self):
         orientation = self.orientation
-        self.im.reformat(orientation)
+        self.im.reformat(orientation, inplace=True)
         im = self.im.volume
         im = im / np.max(im)
         if self.mask:
-            self.mask.reformat(orientation)
+            self.mask.reformat(orientation, inplace=True)
             label_image = label(self.mask.volume)
             im = self.__labeltorgb_3d__(im, label_image, 0.3)
 

--- a/dosma/models/oaiunet2d.py
+++ b/dosma/models/oaiunet2d.py
@@ -129,7 +129,7 @@ class OAIUnet2D(KerasSegModel):
         vol_copy = deepcopy(volume)
 
         # reorient to the sagittal plane
-        vol_copy.reformat(SAGITTAL)
+        vol_copy.reformat(SAGITTAL, inplace=True)
 
         vol = vol_copy.volume
         vol = self.__preprocess_volume__(vol)
@@ -150,7 +150,7 @@ class OAIUnet2D(KerasSegModel):
         vol_copy.volume = mask
 
         # reorient to match with original volume
-        vol_copy.reformat(volume.orientation)
+        vol_copy.reformat(volume.orientation, inplace=True)
 
         return vol_copy
 
@@ -268,7 +268,7 @@ class IWOAIOAIUnet2D(OAIUnet2D):
         vol_copy = deepcopy(volume)
 
         # reorient to the sagittal plane
-        vol_copy.reformat(SAGITTAL)
+        vol_copy.reformat(SAGITTAL, inplace=True)
 
         vol = vol_copy.volume
         vol = self.__preprocess_volume__(vol)
@@ -292,7 +292,7 @@ class IWOAIOAIUnet2D(OAIUnet2D):
             vol_cp.volume = mask[..., i]
 
             # reorient to match with original volume
-            vol_cp.reformat(volume.orientation)
+            vol_cp.reformat(volume.orientation, inplace=True)
             vols[category] = vol_cp
 
         return vols

--- a/dosma/quant_vals.py
+++ b/dosma/quant_vals.py
@@ -171,8 +171,7 @@ class QuantitativeValue(ABC):
             valid_mask &= lb_mask & ub_mask
 
         if mask is not None:
-            mask = mask.clone(headers=False)
-            mask.reformat(self.volumetric_map.orientation)
+            mask = mask.reformat(self.volumetric_map.orientation)
             mask = mask.volume
 
             if labels is None:

--- a/dosma/tissues/tissue.py
+++ b/dosma/tissues/tissue.py
@@ -104,7 +104,7 @@ class Tissue(ABC):
         if self.__mask__ is None:
             raise ValueError("Please initialize mask for {}".format(self.FULL_NAME))
 
-        quant_map.reformat(self.__mask__.orientation)
+        quant_map.reformat(self.__mask__.orientation, inplace=True)
         pass
 
     def __store_quant_vals__(self, quant_map: MedicalVolume, quant_df: pd.DataFrame, map_type: QuantitativeValueType):
@@ -230,7 +230,7 @@ class Tissue(ABC):
             mask (MedicalVolume): Binary mask of segmented tissue.
         """
         assert type(mask) is MedicalVolume, "mask for tissue must be of type MedicalVolume"
-        mask.reformat(SAGITTAL)
+        mask.reformat(SAGITTAL, inplace=True)
         self.__mask__ = mask
 
     def get_mask(self):

--- a/dosma/utils/fits.py
+++ b/dosma/utils/fits.py
@@ -62,20 +62,16 @@ class MonoExponentialFit(_Fit):
             raise ValueError("`len(ts)`={:d}, but `len(subvolumes)`={:d}".format(len(ts), len(subvolumes)))
         self.ts = ts
 
+        orientation = subvolumes[0].orientation
+        subvolumes = [sv.reformat(orientation) for sv in subvolumes]
         self.subvolumes = subvolumes
 
         if mask and not isinstance(mask, MedicalVolume):
             raise TypeError("`mask` must be a MedicalVolume")
-        self.mask = mask
+        self.mask = mask.reformat(orientation)
+
         self.verbose = verbose
         self.num_workers = num_workers
-
-        orientation = self.subvolumes[0].orientation
-        for sv in self.subvolumes[1:]:
-            sv.reformat(orientation)
-
-        if self.mask:
-            self.mask.reformat(orientation)
 
         if len(bounds) != 2:
             raise ValueError("`bounds` should provide lower/upper bound in format (lb, ub)")

--- a/tests/data_io/test_io.py
+++ b/tests/data_io/test_io.py
@@ -245,7 +245,7 @@ class TestDicomIO(unittest.TestCase):
                 o_new = tuple(o_new)
                 orientations.append(o_new)
 
-                volumes[i].reformat(o_new)
+                volumes[i].reformat(o_new, inplace=True)
                 self.dw.save(volumes[i], os.path.join(write_path, 'e%d' % (i + 1)))
 
                 # orientations should be preserved after saving
@@ -254,13 +254,13 @@ class TestDicomIO(unittest.TestCase):
             # Currently saving dicom flipped axis (i.e. changing scanner origin) is not supported
             # check to make sure error is raised
             o3 = (o[0][::-1], o[1], o[2])
-            volumes[0].reformat(o3)
+            volumes[0].reformat(o3, inplace=True)
             with self.assertRaises(ValueError):
                 self.dw.save(volumes[0], ututils.TEMP_PATH)
 
             # reformat with dicom-specific orientation (o) to compare to loaded echos
             for vol in volumes:
-                vol.reformat(o)
+                vol.reformat(o, inplace=True)
 
             # Load echos from write (save) path
             load_echos_paths = [os.path.join(write_path, 'e%d' % (i + 1)) for i in range(len(volumes))]
@@ -347,7 +347,7 @@ class TestInterIO(unittest.TestCase):
 
                 nifti_vol = self.nr.load(nfp)
                 dicom_vol = self.dr.load(dfp)[0]
-                dicom_vol.reformat(nifti_vol.orientation)
+                dicom_vol.reformat(nifti_vol.orientation, inplace=True)
 
                 # assert nifti_vol.is_same_dimensions(dicom_vol)
                 assert (nifti_vol.volume == dicom_vol.volume).all()
@@ -376,7 +376,7 @@ class TestInterIO(unittest.TestCase):
                     "Orientations of multiple dicom volumes loaded from single folder should be identical"
 
             for v in gt_nifti_vols:
-                v.reformat(o)
+                v.reformat(o, inplace=True)
 
             for i in range(len(dicom_loaded_vols)):
                 dcm_vol = dicom_loaded_vols[i]

--- a/tests/data_io/test_med_volume.py
+++ b/tests/data_io/test_med_volume.py
@@ -23,9 +23,24 @@ class TestMedicalVolume(unittest.TestCase):
     def test_reformat(self):
         mv = MedicalVolume(np.random.rand(10,20,30), self._AFFINE)
         new_orientation = tuple(x[::-1] for x in mv.orientation[::-1])
+
         mv2 = mv.reformat(new_orientation)
         assert mv2.orientation == new_orientation
-        assert id(mv) == id(mv2)
+        assert id(mv2) != id(mv)
+        assert np.shares_memory(mv2._volume, mv._volume)
+
+        mv2 = mv.reformat(new_orientation, inplace=True)
+        assert mv2.orientation == new_orientation
+        assert id(mv2) == id(mv)
+        assert np.shares_memory(mv2._volume, mv._volume)
+
+        mv2 = mv.reformat(mv.orientation)
+        assert id(mv2) != id(mv)
+        assert np.shares_memory(mv2._volume, mv._volume)
+
+        mv2 = mv.reformat(mv.orientation, inplace=True)
+        assert id(mv2) == id(mv)
+        assert np.shares_memory(mv2._volume, mv._volume)
 
     def test_reformat_as(self):
         mv = MedicalVolume(np.random.rand(10,20,30), self._AFFINE)

--- a/tests/data_io/test_orientation.py
+++ b/tests/data_io/test_orientation.py
@@ -33,10 +33,10 @@ class TestOrientation(unittest.TestCase):
 
         for o in orientations:
             # Reorient to some orientation
-            mv.reformat(o)
+            mv.reformat(o, inplace=True)
 
             # Reorient to original orientation
-            mv.reformat(o_base)
+            mv.reformat(o_base, inplace=True)
 
             assert mv.orientation == o_base, "Orientation mismatch: Expected %s, got %s" % (str(o_base),
                                                                                             str(mv.orientation))


### PR DESCRIPTION
`MedicalVolume.reformat` was previously an in-place operation, directly modifying attributes of `self`. However, for conventional reasons, in-place operations should be made optional and `False` by default.

An optional argument `inplace` with default value `False` was added to both `reformat` and `reformat_as` methods. Other code in the codebase that used `inplace` was modified to either use the shallow copy output of reformat (`inplace=False`) or modified to include the optional argument `inplace=True`.