### PR TITLE
Add multi-dimension header functionality

### DIFF
--- a/docs/source/general/guide_basic.rst
+++ b/docs/source/general/guide_basic.rst
@@ -29,6 +29,16 @@ We can also load specific files in the image series:
 >>> with DicomReader() as dr:
 >>>   volumes = dr.load(["file1", "file2", ...], group_by="EchoNumbers")
 
+DICOM image data often has associated metadata. :class:`MedicalVolume` makes it easy to get
+and set metadata:
+
+>>> volume = volumes[0]  # first echo time
+>>> volume.get_metadata("EchoTime", float)
+10.0
+>>> volume.set_metadata("EchoTime", 20)
+>>> volume.get_metadata("EchoTime", float)
+20.0
+
 Similarly, to load a NIfTI volume, we use the :class:`NiftiReader` class:
 
 >>> from dosma.data_io import NiftiReader

--- a/dosma/data_io/med_volume.py
+++ b/dosma/data_io/med_volume.py
@@ -690,6 +690,11 @@ class MedicalVolume(NDArrayOperatorsMixin):
         return self._partial_clone(volume=volume, affine=affine, headers=headers)
 
     def __setitem__(self, _slice, value):
+        """
+        Note:
+            When ``value`` is a ``MedicalVolume``, the headers from that value
+            are not copied over. This may be changed in the future.
+        """
         if isinstance(value, MedicalVolume):
             image = self[_slice]
             assert value.is_same_dimensions(image, err=True)

--- a/dosma/scan_sequences/cones.py
+++ b/dosma/scan_sequences/cones.py
@@ -61,7 +61,7 @@ class Cones(NonTargetSequence):
 
         echo_times = []
         for vol in self.volumes:
-            echo_times.append(float(vol.headers[0].EchoTime))
+            echo_times.append(float(vol.get_metadata("EchoTime")))
 
         self.echo_times = natsorted(echo_times)
 

--- a/dosma/scan_sequences/mapss.py
+++ b/dosma/scan_sequences/mapss.py
@@ -67,7 +67,7 @@ class Mapss(TargetSequence):
 
     def __load_dicom__(self):
         super().__load_dicom__()
-        self.echo_times = [float(x.headers[0].EchoTime) for x in self.volumes]
+        self.echo_times = [float(x.get_metadata("EchoTime")) for x in self.volumes]
 
     def __validate_scan__(self):
         return len(self.volumes) == 7
@@ -142,7 +142,7 @@ class Mapss(TargetSequence):
             intrareg_vol = MedicalVolume(
                 volume=intrareg_vol.volume,
                 affine=volumes[echo_index].affine,
-                headers=deepcopy(volumes[echo_index].headers),
+                headers=deepcopy(volumes[echo_index].headers()),
             )
 
             intraregistered_volumes.append(intrareg_vol)

--- a/dosma/scan_sequences/qdess.py
+++ b/dosma/scan_sequences/qdess.py
@@ -9,7 +9,6 @@ from pydicom.tag import Tag
 
 from dosma.data_io import format_io_utils as fio_utils
 from dosma.data_io.format_io import ImageDataFormat
-from dosma.data_io.med_volume import MedicalVolume
 from dosma.defaults import preferences
 from dosma.models.seg_model import SegModel
 from dosma.quant_vals import T2
@@ -203,9 +202,7 @@ class QDess(TargetSequence):
             vol_null_fluid = echo_1 - beta * echo_2
             t2map = t2map * (vol_null_fluid > 0.1 * xp.max(vol_null_fluid))
 
-        t2_map_wrapped = MedicalVolume(
-            t2map, affine=subvolumes[0].affine, headers=deepcopy(subvolumes[0].headers)
-        )
+        t2_map_wrapped = subvolumes[0]._partial_clone(volume=t2map, headers=True)
         t2_map_wrapped = T2(t2_map_wrapped)
 
         tissue.add_quantitative_value(t2_map_wrapped)

--- a/dosma/scan_sequences/scans.py
+++ b/dosma/scan_sequences/scans.py
@@ -131,7 +131,7 @@ class ScanSequence(ABC):
 
         self.volumes = dr.load(dicom_path, group_by=split_by, ignore_ext=self.ignore_ext)
 
-        self.ref_dicom = self.volumes[0].headers[0]
+        self.ref_dicom = self.volumes[0].headers(flatten=True)[0]
 
         self.__set_series_number__(self.ref_dicom.SeriesNumber)
 
@@ -375,7 +375,7 @@ class NonTargetSequence(ScanSequence):
         echo_times = []
 
         for i in range(num_echo_times):
-            echo_time = float(volumes[i].headers[0].EchoTime)
+            echo_time = float(volumes[i].get_metadata("EchoTime"))
             echo_times.append((i, echo_time))
 
         # Sort list of tuples (ind, echo_time) by echo_time

--- a/setup.py
+++ b/setup.py
@@ -82,5 +82,7 @@ setup(
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Operating System :: OS Independent",
     ],
-    extras_require={"dev": ["flake8", "isort", "black==19.3b0", "sphinx", "sphinxcontrib.bibtex"]},
+    extras_require={
+        "dev": ["flake8", "isort", "black==19.3b0", "simpleitk", "sphinx", "sphinxcontrib.bibtex"]
+    },
 )

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,10 +1,14 @@
+import datetime
 import os
 import re
 import shutil
+import tempfile
 import unittest
 import uuid
 
 import natsort
+import numpy as np
+from pydicom.dataset import FileDataset, FileMetaDataset
 
 from dosma.cli import SUPPORTED_SCAN_TYPES, parse_args
 from dosma.data_io.format_io import ImageDataFormat
@@ -28,6 +32,26 @@ SCAN_DIRPATHS = [os.path.join(UNITTEST_SCANDATA_PATH, x) for x in SCANS]
 
 # Decimal precision for analysis (quantitative values, etc)
 DECIMAL_PRECISION = 1  # (+/- 0.1ms)
+
+
+def build_dummy_headers(shape, fields=None):
+    """Build dummy ``pydicom.FileDataset`` headers.
+
+    Note these headers are not dicom compliant and should not be used to write out DICOM
+    files.
+
+    Args:
+        shape (int or tuple[int]): Shape of headers array.
+        fields (Dict): Fields and corresponding values to use to populate the header.
+
+    Returns:
+        ndarray: Headers
+    """
+    if isinstance(shape, int):
+        shape = (shape,)
+    num_headers = np.prod(shape)
+    headers = np.asarray([_build_dummy_pydicom_header(fields) for _ in range(num_headers)])
+    return headers.reshape(shape)
 
 
 def get_scan_dirpath(scan: str):
@@ -80,6 +104,47 @@ def requires_packages(*packages):
         return _wrapper
 
     return _decorator
+
+
+def _build_dummy_pydicom_header(fields=None):
+    """Builds dummy pydicom-based header.
+
+    Note these headers are not dicom compliant and should not be used to write out DICOM
+    files.
+
+    Adapted from
+    https://pydicom.github.io/pydicom/dev/auto_examples/input_output/plot_write_dicom.html
+    """
+    suffix = ".dcm"
+    filename_little_endian = tempfile.NamedTemporaryFile(suffix=suffix).name
+
+    file_meta = FileMetaDataset()
+    file_meta.MediaStorageSOPClassUID = "1.2.840.10008.5.1.4.1.1.2"
+    file_meta.MediaStorageSOPInstanceUID = "1.2.3"
+    file_meta.ImplementationClassUID = "1.2.3.4"
+
+    # Create the FileDataset instance (initially no data elements, but file_meta supplied).
+    ds = FileDataset(filename_little_endian, {}, file_meta=file_meta, preamble=b"\0" * 128)
+
+    # Add the data elements -- not trying to set all required here. Check DICOM standard.
+    ds.PatientName = "Test^Firstname"
+    ds.PatientID = "123456"
+
+    if fields is not None:
+        for k, v in fields.items():
+            setattr(ds, k, v)
+
+    # Set the transfer syntax
+    ds.is_little_endian = True
+    ds.is_implicit_VR = True
+
+    # Set creation date/time
+    dt = datetime.datetime.now()
+    ds.ContentDate = dt.strftime("%Y%m%d")
+    timeStr = dt.strftime("%H%M%S.%f")  # long format with micro seconds
+    ds.ContentTime = timeStr
+
+    return ds
 
 
 class ScanTest(unittest.TestCase):


### PR DESCRIPTION
Headers hold the metadata for slice(s)/volume(s) in the medical image. As a single scan can have multiple volumes (e.g. multi-echo MRI, time-series CT/MRI, etc.), it is important that headers are also matched with the data they correspond to.

We propose storing header information as an ndarray. Using an array structure allows header information to:
1. support easy slicing
2. be easy to add to / expand dimensions for

### Additions 
- Converted headers to numpy arrays accessible with `MedicalVolume.headers()`
- Updated different scan sequences to use `headers()` call
- Added `MedicalVolume.get_metadata()` and `MedicalVolume.set_metadata()` functions to read/write header fields
- Add  support for writing nD arrays to dicom