### PR TITLE
Basic NumPy Interoperability for MedicalVolumes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -92,7 +92,7 @@ htmlhelp_basename = "DOSMAdoc"
 html_static_path = ["_static"]
 
 # Intersphinx mappings
-intersphinx_mapping = {'numpy': ('https://numpy.org/doc/stable/', None)}
+intersphinx_mapping = {"numpy": ("https://numpy.org/doc/stable/", None)}
 
 # Documentation to include
 todo_include_todos = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -91,6 +91,9 @@ htmlhelp_basename = "DOSMAdoc"
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
+# Intersphinx mappings
+intersphinx_mapping = {'numpy': ('https://numpy.org/doc/stable/', None)}
+
 # Documentation to include
 todo_include_todos = True
 napoleon_use_ivar = True

--- a/docs/source/general/core_api.rst
+++ b/docs/source/general/core_api.rst
@@ -1,10 +1,12 @@
-.. _documentation:
+.. _core_api:
 
 Core API
 ================================================================================
 
 MedicalVolume
 ---------------------------
+.. _core_api_medicalvolume:
+
 .. autosummary::
    :toctree:
    :nosignatures:

--- a/docs/source/general/guide_basic.rst
+++ b/docs/source/general/guide_basic.rst
@@ -89,3 +89,19 @@ For example, the first line will throw an error; the second will not:
 >>> mv = mv[2]
 IndexError: Scalar indices disallowed in spatial dimensions; Use `[x]` or `x:x+1`
 >>> mv[2:3]
+
+
+NumPy Interoperability
+========================================
+
+In addition to standard shape-preserving universal functions (ufuncs) described above,
+:class:`MedicalVolume` also support a subset of other numpy functions that, like the ufuncs,
+operate on the pixel data in the medical volume:
+
+- Boolean Functions: :func:`numpy.all`, :func:`numpy.any`, :func:`numpy.where`
+- Statistics functions: :func:`numpy.mean`, :func:`numpy.sum`, :func:`numpy.std`, :func:`numpy.amin`, :func:`numpy.amax`, :func:`numpy.argmax`, :func:`numpy.argmin`
+- Rounding functions: :func:`numpy.round`, :func:`numpy.around`, :func:`numpy.round_`
+- NaN functions: :func:`numpy.nanmean`, :func:`numpy.nansum`, :func:`numpy.nanstd`, :func:`numpy.nan_to_num`
+
+For example, ``np.all(mv)`` is equivalent to ``np.all(mv.volume)``, except the former will return a :class:`MedicalVolume` object.
+Note, headers are not deep copied.

--- a/dosma/__init__.py
+++ b/dosma/__init__.py
@@ -1,5 +1,8 @@
 """The core module contains functions and classes for musculoskeletal analysis.
 """
+from dosma.data_io.dicom_io import *  # noqa
+from dosma.data_io.med_volume import *  # noqa
+from dosma.data_io.nifti_io import *  # noqa
 from dosma.utils.device import Device  # noqa
 
 # This line will be programatically read/write by setup.py.

--- a/dosma/data_io/med_volume.py
+++ b/dosma/data_io/med_volume.py
@@ -278,7 +278,7 @@ class MedicalVolume(NDArrayOperatorsMixin):
         with idevice:
             return self.is_same_dimensions(mv) and (mv.volume == self.volume).all()
 
-    def __allclose_spacing(self, mv, precision: int = None):
+    def _allclose_spacing(self, mv, precision: int = None, ignore_origin: bool = False):
         """Check if spacing between self and another medical volume is within tolerance.
 
         Tolerance is `10 ** (-precision)`.
@@ -288,17 +288,21 @@ class MedicalVolume(NDArrayOperatorsMixin):
             precision (`int`, optional): Number of significant figures after the decimal.
                 If not specified, check that affine matrices between two volumes are identical.
                 Defaults to `None`.
+            ignore_origin (bool, optional): If ``True``, ignore matching origin in the affine
+                matrix.
 
         Returns:
             bool: `True` if spacing between two volumes within tolerance, `False` otherwise.
         """
-        if precision:
+        if precision is not None:
             tol = 10 ** (-precision)
-            return np.allclose(mv.affine[:3, :3], self.affine[:3, :3], atol=tol) and np.allclose(
-                mv.scanner_origin, self.scanner_origin, rtol=tol
+            return np.allclose(mv.affine[:3, :3], self.affine[:3, :3], atol=tol) and (
+                ignore_origin or np.allclose(mv.scanner_origin, self.scanner_origin, rtol=tol)
             )
         else:
-            return (mv.affine == self.affine).all()
+            return (mv.affine == self.affine).all() or (
+                ignore_origin and (mv.affine[:, :3] == self.affine[:, :3]).all()
+            )
 
     def is_same_dimensions(self, mv, precision: int = None, err: bool = False):
         """Check if two volumes have the same dimensions.
@@ -325,7 +329,7 @@ class MedicalVolume(NDArrayOperatorsMixin):
         if not isinstance(mv, MedicalVolume):
             raise TypeError("`mv` must be a MedicalVolume.")
 
-        is_close_spacing = self.__allclose_spacing(mv, precision)
+        is_close_spacing = self._allclose_spacing(mv, precision)
         is_same_orientation = mv.orientation == self.orientation
         is_same_shape = mv.volume.shape == self.volume.shape
         out = is_close_spacing and is_same_orientation and is_same_shape
@@ -1075,6 +1079,8 @@ def around(x, decimals=0, affine=False):
 def stack(xs, axis: int = -1):
     """Stack medical images across non-spatial dimensions.
 
+    Images will be auto-oriented to the orientation of the first medical volume.
+
     Args:
         xs (array-like[MedicalVolume]): 1D array-like of aligned medical images to stack.
         axis (int, optional): Axis to stack along.
@@ -1092,6 +1098,7 @@ def stack(xs, axis: int = -1):
     if not isinstance(axis, int):
         raise TypeError(f"'{type(axis)}' cannot be interpreted as int")
 
+    xs = [x.reformat(xs[0].orientation) for x in xs]
     affine = xs[0].affine
     for x in xs[1:]:
         assert x.is_same_dimensions(xs[0], err=True)
@@ -1099,6 +1106,7 @@ def stack(xs, axis: int = -1):
         axis = _to_positive_axis(axis, len(xs[0].shape), grow=True, invalid_axis="spatial")
     except ValueError:
         raise ValueError(f"Cannot stack across spatial dimension (axis={axis})")
+    assert axis >= 0
 
     vol = np.stack([x.volume for x in xs], axis=axis)
     headers = [x.headers() for x in xs]
@@ -1110,14 +1118,90 @@ def stack(xs, axis: int = -1):
     return MedicalVolume(vol, affine, headers=headers)
 
 
-# @implements(np.concatenate)
-# def concatenate(xs, axis: int = -1):
-#     """Concatenate medical images.
-#     Note:
-#         Headers are not set unless all inputs have headers of the same
-#         shape. This functionality may change in the future.
-#     """
-#     pass
+@implements(np.concatenate)
+def concatenate(xs, axis: int = -1):
+    """Concatenate medical images.
+
+    Image concatenation is slightly different if the axis is a spatial axis
+    (one of the first 3 dimensions) or a non-spatial dimension.
+
+    If concatenating along a non-spatial dimension, the image dimensions for all
+    other axes and affine matrix of each ``x`` must be the same, which is standard
+    for concatenation.
+
+    If concatenating along a spatial dimension, all images must have the same direction
+    and pixel spacing. Additionally, the scanner origin for all spatial axes not being
+    concatenated should be the same. The origin for other scans should be consecutive.
+    For example, if images are concatenated on ``axis=i``, a spatial axis, then
+    ``xs[0].scanner_origin + xs[0].``.
+
+    Images will be auto-oriented to the orientation of the first medical volume.
+
+    Note:
+        Headers are not set unless all inputs have headers of the same
+        shape. This functionality may change in the future.
+    """
+    precision = None
+    tol = 10 ** (-precision) if precision is not None else None
+
+    if not isinstance(axis, int):
+        raise TypeError(f"'{type(axis)}' cannot be interpreted as int")
+
+    xs = [x.reformat(xs[0].orientation) for x in xs]
+    axis = _to_positive_axis(axis, len(xs[0].shape), grow=False, invalid_axis=None)
+    assert axis >= 0
+
+    if axis in range(3):
+        # Concatenate along spatial dimension
+        for i, x in enumerate(xs[1:]):
+            if not x._allclose_spacing(xs[0], precision=precision, ignore_origin=True):
+                raise ValueError(
+                    "All the inputs must have the same direction and pixel spacing "
+                    "when concatenating spatial dimensions, but input at index 0 "
+                    "has affine {} and the input at index {} "
+                    "has affine {}".format(xs[0].affine[:3, :3], i, x.affine[:3, :3])
+                )
+        for i, (x1, x2) in enumerate(zip(xs[:-1], xs[1:])):
+            ijk1 = np.array([0, 0, 0, 1])
+            ijk1[axis] = x1.shape[axis]
+            xyz = x1.affine.dot(ijk1)[:3]
+            if not (
+                (precision is not None and np.allclose(x2.scanner_origin, xyz, rtol=tol))
+                or (np.asarray(x2.scanner_origin) == xyz).all()
+            ):
+                raise ValueError(
+                    "All the inputs must be sequentially increasing in space "
+                    "when concatenating spatial dimensions, but input at index {} "
+                    "ends at xyz location {} and the input at index {} "
+                    "starts at xyz location {}".format(i, xyz, i + 1, x2.scanner_origin)
+                )
+    else:
+        for i, x in enumerate(xs[1:]):
+            if not x._allclose_spacing(xs[0], precision=precision):
+                raise ValueError(
+                    "All the inputs must have the same affine matrix "
+                    "when concatenating non-spatial dimensions, but input at index 0 "
+                    "has affine {} and the input at index {} "
+                    "has affine {}".format(xs[0].affine, i, x.affine)
+                )
+
+    volume = np.concatenate([x.volume for x in xs], axis=axis)
+    headers = [x.headers() for x in xs]
+    if any(x is None for x in headers):
+        headers = None
+    else:
+        headers = np.concatenate(headers, axis=axis)
+        if headers.ndim != volume.ndim or any(
+            [hs != 1 and hs != vs for hs, vs in zip(headers.shape, volume.shape)]
+        ):
+            warnings.warn(
+                "Got invalid headers shape ({}) given concatenated output shape ({}). "
+                "Expected header dimensions to be 1 or same as volume dimension for all axes. "
+                "Dropping all headers in concatenated output.".format(volume.shape, headers.shape)
+            )
+            headers = None
+
+    return MedicalVolume(volume, xs[0].affine, headers=headers)
 
 
 @implements(np.expand_dims)

--- a/dosma/data_io/med_volume.py
+++ b/dosma/data_io/med_volume.py
@@ -5,7 +5,7 @@ This module defines `MedicalVolume`, which is a wrapper for 3D volumes.
 import warnings
 from copy import deepcopy
 from numbers import Number
-from typing import Sequence
+from typing import Sequence, Tuple, Union
 
 import nibabel as nib
 import numpy as np
@@ -26,6 +26,9 @@ if env.package_available("h5py"):
     import h5py
 
 __all__ = ["MedicalVolume"]
+
+
+_HANDLED_NUMPY_FUNCTIONS = {}
 
 
 class MedicalVolume(NDArrayOperatorsMixin):
@@ -546,6 +549,31 @@ class MedicalVolume(NDArrayOperatorsMixin):
             else:
                 h[key].value = value
 
+    def round(self, decimals=0, affine=False):
+        return around(self, decimals, affine)
+
+    def sum(
+        self,
+        axis=None,
+        dtype=None,
+        out=None,
+        keepdims=False,
+        initial=np._NoValue,
+        where=np._NoValue,
+    ):
+        """Identical to :method:``sum_np``."""
+        # `out` is required for cupy arrays because of how cupy calls array.
+        if out is not None:
+            raise ValueError("`out` must be None")
+        return sum_np(self, axis=axis, dtype=dtype, keepdims=keepdims, initial=initial, where=where)
+
+    def mean(self, axis=None, dtype=None, out=None, keepdims=False, where=np._NoValue):
+        """Identical to :method:``mean_np``."""
+        # `out` is required for cupy arrays because of how cupy calls array.
+        if out is not None:
+            raise ValueError("`out` must be None")
+        return mean_np(self, axis=axis, dtype=dtype, keepdims=keepdims, where=where)
+
     @property
     def volume(self):
         """ndarray: 3D ndarray representing volume values."""
@@ -692,6 +720,70 @@ class MedicalVolume(NDArrayOperatorsMixin):
         headers = np.reshape(headers, shape)
         return headers
 
+    def _extract_input_array_ufunc(self, input, device=None):
+        if device is None:
+            device = self.device
+        device_err = "Expected device {} but got device ".format(device) + "{}"
+        if isinstance(input, Number):
+            return input
+        elif isinstance(input, np.ndarray):
+            if device != cpu_device:
+                raise RuntimeError(device_err.format(cpu_device))
+            return input
+        elif env.cupy_available() and isinstance(input, cp.ndarray):
+            if device != input.device:
+                raise RuntimeError(device_err.format(Device(input.device)))
+            return input
+        elif isinstance(input, MedicalVolume):
+            if device != input.device:
+                raise RuntimeError(device_err.format(Device(input.device)))
+            assert self.is_same_dimensions(input, err=True)
+            return input._volume
+        else:
+            return NotImplemented
+
+    def _check_reduce_axis(self, axis: Union[int, Sequence[int]]) -> Tuple[int]:
+        if axis is None:
+            return None
+        is_sequence = isinstance(axis, Sequence)
+        if not is_sequence:
+            axis = (axis,)
+        axis = tuple(x if x >= 0 else self.volume.ndim + x for x in axis)
+        assert all(x >= 0 for x in axis)
+        if any(x < 3 for x in axis):
+            raise ValueError("Cannot reduce MedicalVolume along spatial dimensions")
+        if not is_sequence:
+            axis = axis[0]
+        return axis
+
+    def _reduce_array(self, func, *inputs, **kwargs) -> "MedicalVolume":
+        """
+        Assumes inputs have been verified.
+        """
+        device = self.device
+        xp = device.xp
+
+        keepdims = kwargs.get("keepdims", False)
+        reduce_axis = self._check_reduce_axis(kwargs["axis"])
+        kwargs["axis"] = reduce_axis
+        if not isinstance(reduce_axis, Sequence):
+            reduce_axis = (reduce_axis,)
+        with device:
+            volume = func(*inputs, **kwargs)
+
+        if xp.isscalar(volume) or volume.ndim == 0:
+            return volume
+
+        if self._headers is not None:
+            headers_slices = tuple(
+                slice(None) if x not in reduce_axis else slice(0, 1) if keepdims else 0
+                for x in range(self._headers.ndim)
+            )
+            headers = self._headers[headers_slices]
+        else:
+            headers = None
+        return self._partial_clone(volume=volume, headers=headers)
+
     def __getitem__(self, _slice):
         slicer = _SpatialFirstSlicer(self)
         try:
@@ -784,7 +876,6 @@ class MedicalVolume(NDArrayOperatorsMixin):
             >>> a = np.asarray(mv)
             >>> type(a)
             <class 'numpy.ndarray'>
-            >>> np.log()
 
         Note:
             This is not valid when ``self.volume`` is a ``cupy.ndarray``.
@@ -800,28 +891,24 @@ class MedicalVolume(NDArrayOperatorsMixin):
             )
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        if method == "__call__":
+        def _extract_inputs(inputs, device):
             _inputs = []
-            device = self.device
-            device_err = "Expected device {} but got device ".format(self.device) + "{}"
             for input in inputs:
-                if isinstance(input, Number):
-                    _inputs.append(input)
-                elif isinstance(input, np.ndarray):
-                    if device != cpu_device:
-                        raise RuntimeError(device_err.format(cpu_device))
-                    _inputs.append(input)
-                elif env.cupy_available() and isinstance(input, cp.ndarray):
-                    if device != input.device:
-                        raise RuntimeError(device_err.format(Device(input.device)))
-                    _inputs.append(input)
-                elif isinstance(input, MedicalVolume):
-                    if device != input.device:
-                        raise RuntimeError(device_err.format(Device(input.device)))
-                    assert self.is_same_dimensions(input, err=True)
-                    _inputs.append(input._volume)
-                else:
-                    return NotImplemented
+                input = self._extract_input_array_ufunc(input, device)
+                if input is NotImplemented:
+                    return input
+                _inputs.append(input)
+            return _inputs
+
+        if method not in ["__call__", "reduce"]:
+            return NotImplemented
+
+        device = self.device
+        _inputs = _extract_inputs(inputs, device)
+        if _inputs is NotImplemented:
+            return NotImplemented
+
+        if method == "__call__":
             with device:
                 volume = ufunc(*_inputs, **kwargs)
             if volume.shape != self._volume.shape:
@@ -829,11 +916,18 @@ class MedicalVolume(NDArrayOperatorsMixin):
                     f"{self.__class__.__name__} does not support operations that change shape. "
                     f"Use operations on `self.volume` to modify array objects."
                 )
-            if volume.dtype == np.bool:
-                volume = volume.astype(np.uint8)
             return self._partial_clone(volume=volume)
-        else:
+        elif method == "reduce":
+            return self._reduce_array(ufunc.reduce, *_inputs, **kwargs)
+
+    def __array_function__(self, func, types, args, kwargs):
+        if func not in _HANDLED_NUMPY_FUNCTIONS:
             return NotImplemented
+        # Note: this allows subclasses that don't override
+        # __array_function__ to handle MedicalVolume objects.
+        if not all(issubclass(t, (MedicalVolume, self.__class__)) for t in types):
+            return NotImplemented
+        return _HANDLED_NUMPY_FUNCTIONS[func](*args, **kwargs)
 
     @property
     def __cuda_array_interface__(self):
@@ -854,3 +948,255 @@ class _SpatialFirstSlicer(_SpatialFirstSlicerNib):
 
     def __getitem__(self, slicer):
         raise NotImplementedError("Slicing should be done by `MedicalVolume`")
+
+
+# =================================
+# Supported numpy functions
+# =================================
+def implements(*np_functions):
+    "Register an __array_function__ implementation for DiagonalArray objects."
+
+    def decorator(func):
+        for np_func in np_functions:
+            _HANDLED_NUMPY_FUNCTIONS[np_func] = func
+        return func
+
+    return decorator
+
+
+def reduce_array_op(func, x, axis=None, **kwargs):
+    kwargs = {k: v for k, v in kwargs.items() if v != np._NoValue}
+    input = x._extract_input_array_ufunc(x)
+    if input is NotImplemented:
+        return NotImplemented
+    return x._reduce_array(func, input, axis=axis, **kwargs)
+
+
+@implements(np.amin)
+def amin(x, axis=None, keepdims=False, initial=np._NoValue, where=np._NoValue):
+    return reduce_array_op(np.amin, x, axis=axis, keepdims=keepdims, initial=initial, where=where)
+
+
+@implements(np.amax)
+def amax(x, axis=None, keepdims=False, initial=np._NoValue, where=np._NoValue):
+    return reduce_array_op(np.amax, x, axis=axis, keepdims=keepdims, initial=initial, where=where)
+
+
+@implements(np.argmin)
+def argmin(x, axis=None):
+    return reduce_array_op(np.argmin, x, axis=axis)
+
+
+@implements(np.argmax)
+def argmax(x, axis=None):
+    return reduce_array_op(np.argmax, x, axis=axis)
+
+
+@implements(np.sum)
+def sum_np(x, axis=None, dtype=None, keepdims=False, initial=np._NoValue, where=np._NoValue):
+    return reduce_array_op(
+        np.sum, x, axis=axis, dtype=dtype, keepdims=keepdims, initial=initial, where=where
+    )
+
+
+@implements(np.mean)
+def mean_np(x, axis=None, dtype=None, keepdims=False, where=np._NoValue):
+    return reduce_array_op(np.mean, x, axis=axis, dtype=dtype, keepdims=keepdims, where=where)
+
+
+@implements(np.std)
+def std(x, axis=None, dtype=None, ddof=0, keepdims=False, where=np._NoValue):
+    return reduce_array_op(
+        np.std, x, axis=axis, dtype=dtype, ddof=ddof, keepdims=keepdims, where=where
+    )
+
+
+@implements(np.nanmin)
+def nanmin(x, axis=None, keepdims=False):
+    return reduce_array_op(np.nanmin, x, axis=axis, keepdims=keepdims)
+
+
+@implements(np.nanmax)
+def nanmax(x, axis=None, keepdims=False):
+    return reduce_array_op(np.nanmax, x, axis=axis, keepdims=keepdims)
+
+
+@implements(np.nanargmin)
+def nanargmin(x, axis=None):
+    return reduce_array_op(np.nanargmin, x, axis=axis)
+
+
+@implements(np.nanargmax)
+def nanargmax(x, axis=None):
+    return reduce_array_op(np.nanargmax, x, axis=axis)
+
+
+@implements(np.nansum)
+def nansum(x, axis=None, dtype=None, keepdims=False):
+    return reduce_array_op(np.nansum, x, axis=axis, dtype=dtype, keepdims=keepdims)
+
+
+@implements(np.nanmean)
+def nanmean(x, axis=None, dtype=None, keepdims=False):
+    return reduce_array_op(np.nanmean, x, axis=axis, dtype=dtype, keepdims=keepdims)
+
+
+@implements(np.nanstd)
+def nanstd(x, axis=None, dtype=None, ddof=0, keepdims=False):
+    return reduce_array_op(np.nanstd, x, axis=axis, dtype=dtype, ddof=ddof, keepdims=keepdims)
+
+
+@implements(np.nan_to_num)
+def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
+    vol = np.nan_to_num(x.volume, copy=copy, nan=nan, posinf=posinf, neginf=neginf)
+    if not copy:
+        x._volume = vol
+        return x
+    else:
+        return x._partial_clone(volume=vol)
+
+
+@implements(np.around, np.round, np.round_)
+def around(x, decimals=0, affine=False):
+    """Round medical image pixel data (and optionally affine) to the given number of decimals.
+
+    Args:
+        x (MedicalVolume): A medical image.
+        decimals (int, optional): Number of decimal places to round to.
+            If decimals is negative, it specifies the number of positions to the left
+            of the decimal point.
+        affine (bool, optional): If ``True``, rounds affine matrix.
+    """
+    affine = np.around(x.affine, decimals=decimals) if affine else x.affine
+    return x._partial_clone(volume=np.around(x.volume, decimals=decimals), affine=affine)
+
+
+@implements(np.stack)
+def stack(xs, axis: int = -1):
+    """Stack medical images across non-spatial dimensions.
+
+    Args:
+        xs (array-like[MedicalVolume]): 1D array-like of aligned medical images to stack.
+        axis (int, optional): Axis to stack along.
+
+    Returns:
+        MedicalVolume: Stack
+
+    Note:
+        Unlike NumPy, the default stacking axis is ``-1``.
+
+    Note:
+        Headers are not set unless all inputs have headers of the same
+        shape. This functionality may change in the future.
+    """
+    if not isinstance(axis, int):
+        raise TypeError(f"'{type(axis)}' cannot be interpreted as int")
+
+    affine = xs[0].affine
+    for x in xs[1:]:
+        assert x.is_same_dimensions(xs[0], err=True)
+    try:
+        axis = _to_positive_axis(axis, len(xs[0].shape), grow=True, invalid_axis="spatial")
+    except ValueError:
+        raise ValueError(f"Cannot stack across spatial dimension (axis={axis})")
+
+    vol = np.stack([x.volume for x in xs], axis=axis)
+    headers = [x.headers() for x in xs]
+    if any(x is None for x in headers):
+        headers = None
+    else:
+        headers = np.stack(headers, axis=axis)
+
+    return MedicalVolume(vol, affine, headers=headers)
+
+
+# @implements(np.concatenate)
+# def concatenate(xs, axis: int = -1):
+#     """Concatenate medical images.
+#     Note:
+#         Headers are not set unless all inputs have headers of the same
+#         shape. This functionality may change in the future.
+#     """
+#     pass
+
+
+@implements(np.expand_dims)
+def expand_dims(x, axis: Union[int, Sequence[int]]):
+    """Expand across non-spatial dimensions.
+
+    Args:
+        x (MedicalVolume): A medical image.
+        axis (``int(s)``): Axis/axes to expand dimensions.
+
+    Returns:
+        MedicalVolume: The medical image with expanded dimensions.
+    """
+    try:
+        axis = _to_positive_axis(axis, len(x.shape), grow=True, invalid_axis="spatial")
+    except ValueError:
+        raise ValueError(f"Cannot expand across spatial dimensions (axis={axis})")
+    vol = np.expand_dims(x.volume, axis)
+    headers = x.headers()
+    if headers is not None:
+        headers = np.expand_dims(headers, axis)
+    return x._partial_clone(volume=vol, headers=headers)
+
+
+@implements(np.where)
+def where(*args, **kwargs):
+    return np.where(np.asarray(args[0]), *args[1:], **kwargs)
+
+
+@implements(np.all)
+def all_np(x, axis=None, keepdims=np._NoValue):
+    return reduce_array_op(np.all, x, axis=axis, keepdims=keepdims)
+
+
+@implements(np.any)
+def any_np(x, axis=None, keepdims=np._NoValue):
+    return reduce_array_op(np.any, x, axis=axis, keepdims=keepdims)
+
+
+def _to_positive_axis(
+    axis: Union[int, Sequence[int]],
+    ndim: int,
+    grow: bool = False,
+    invalid_axis: Union[int, Sequence[int]] = None,
+):
+    """
+    Args:
+        axis (``int(s)``): The axis/axes to convert to positive.
+        ndim (int): The current dimension.
+        grow (bool, optional): If ``True``, converts axes to positive
+            positions based on new dimension. The new dimension is
+            calculated as ``ndim + #(axes < 0) + #(axes >= ndim)``.
+        invalid_axis (bool, optional): Axes that are invalid.
+            These should all be positive as check is done after
+            positive.
+
+    Returns:
+        int(s): The positively formatted axes.
+    """
+    original_axis = axis
+
+    is_sequence = isinstance(axis, Sequence)
+    if not is_sequence:
+        axis = (axis,)
+    if grow:
+        ndim += sum(tuple(x < 0 or x >= ndim for x in axis))
+    axis = tuple(x if x >= 0 else ndim + x for x in axis)
+
+    if invalid_axis is not None:
+        if invalid_axis == "spatial":
+            invalid_axis = tuple(range(0, 3))
+        elif not isinstance(invalid_axis, Sequence):
+            assert isinstance(invalid_axis, int)
+            invalid_axis = (invalid_axis,)
+        if any(x in invalid_axis for x in axis):
+            raise ValueError(
+                f"Invalid axes {original_axis}. Specified axes should not be in axes {invalid_axis}"
+            )
+
+    if not is_sequence:
+        axis = axis[0]
+    return axis

--- a/tests/data_io/test_med_volume.py
+++ b/tests/data_io/test_med_volume.py
@@ -425,6 +425,18 @@ class TestMedicalVolume(unittest.TestCase):
         with self.assertRaises(ValueError):
             mv2 = np.expand_dims(mv_a, 0)
 
+        mv_d = mv_a[..., :1]
+        assert mv_d.shape == (10, 20, 30, 1)
+        assert np.squeeze(mv_d).shape == (10, 20, 30)
+        assert np.squeeze(mv_d, axis=-1).shape == (10, 20, 30)
+        assert np.squeeze(mv_d, axis=3).shape == (10, 20, 30)
+        assert np.squeeze(mv_d, axis=3).shape == (10, 20, 30)
+
+        mv_d = mv_a[:1, :, :, :1]
+        assert np.squeeze(mv_d).shape == (1, 20, 30)
+        with self.assertRaises(ValueError):
+            np.squeeze(mv_d, axis=0)
+
         with self.assertRaises(ValueError):
             np.concatenate([mv_a, mv_b], axis=0)
 

--- a/tests/data_io/test_med_volume.py
+++ b/tests/data_io/test_med_volume.py
@@ -234,9 +234,188 @@ class TestMedicalVolume(unittest.TestCase):
         assert np.all(np.exp(mv.volume) == np.exp(mv).volume)
 
         mv[np.where(mv == 1)] = 5
-        assert np.all(mv.volume == 5)
+        assert np.all(mv == 5)
+        assert not np.any(mv == 1)
+        assert all(mv == 5)
+        assert not any(mv == 5)
 
         _ = mv + np.ones(mv.shape)
+
+        shape = (10, 20, 30, 2)
+        headers = np.stack(
+            [
+                ututils.build_dummy_headers(shape[2], {"EchoTime": 2}),
+                ututils.build_dummy_headers(shape[2], {"EchoTime": 10}),
+            ],
+            axis=-1,
+        )
+
+        # Reduce functions
+        mv = MedicalVolume(np.random.rand(*shape), np.eye(4), headers=headers)
+
+        mv2 = np.add.reduce(mv, -1)
+        assert np.all(mv2 == np.add.reduce(mv.volume, axis=-1))
+        assert mv2.shape == mv.shape[:3]
+        mv2 = np.add.reduce(mv, axis=None)
+        assert np.all(mv2 == np.add.reduce(mv.volume, axis=None))
+        assert np.isscalar(mv2)
+
+        mv2 = np.sum(mv, axis=-1)
+        assert np.all(mv2 == np.sum(mv.volume, axis=-1))
+        assert mv2.shape == mv.shape[:3]
+        mv2 = np.sum(mv)
+        assert np.all(mv2 == np.sum(mv.volume))
+        assert np.isscalar(mv2)
+
+        mv2 = mv.sum(axis=-1)
+        assert np.all(mv2 == np.sum(mv.volume, axis=-1))
+        assert mv2.shape == mv.shape[:3]
+        mv2 = mv.sum()
+        assert np.all(mv2 == np.sum(mv.volume))
+        assert np.isscalar(mv2)
+
+        mv2 = np.mean(mv, axis=-1)
+        assert np.all(mv2 == np.mean(mv.volume, axis=-1))
+        assert mv2.shape == mv.shape[:3]
+        mv2 = np.mean(mv)
+        assert np.all(mv2 == np.mean(mv.volume))
+        assert np.isscalar(mv2)
+
+        mv2 = mv.mean(axis=-1)
+        assert np.all(mv2 == np.mean(mv.volume, axis=-1))
+        assert mv2.shape == mv.shape[:3]
+        mv2 = mv.mean()
+        assert np.all(mv2 == np.mean(mv.volume))
+        assert np.isscalar(mv2)
+
+        mv2 = np.std(mv, axis=-1)
+        assert np.all(mv2 == np.std(mv.volume, axis=-1))
+        assert mv2.shape == mv.shape[:3]
+        mv2 = np.std(mv)
+        assert np.all(mv2 == np.std(mv.volume))
+        assert np.isscalar(mv2)
+
+        # Min/max functions
+        mv2 = np.amin(mv, axis=-1)
+        assert np.all(mv2 == np.amin(mv.volume, axis=-1))
+        assert mv2.shape == mv.shape[:3]
+        mv2 = np.amin(mv)
+        assert np.all(mv2 == np.amin(mv.volume))
+        assert np.isscalar(mv2)
+
+        mv2 = np.amax(mv, axis=-1)
+        assert np.all(mv2 == np.amax(mv.volume, axis=-1))
+        assert mv2.shape == mv.shape[:3]
+        mv2 = np.amax(mv)
+        assert np.all(mv2 == np.amax(mv.volume))
+        assert np.isscalar(mv2)
+
+        mv2 = np.argmin(mv, axis=-1)
+        assert np.all(mv2 == np.argmin(mv.volume, axis=-1))
+        assert mv2.shape == mv.shape[:3]
+        mv2 = np.argmin(mv)
+        assert np.all(mv2 == np.argmin(mv.volume))
+
+        mv2 = np.argmax(mv, axis=-1)
+        assert np.all(mv2 == np.argmax(mv.volume, axis=-1))
+        assert mv2.shape == mv.shape[:3]
+        mv2 = np.argmax(mv)
+        assert np.all(mv2 == np.argmax(mv.volume))
+
+        # NaN functions
+        vol_nan = np.ones(shape)
+        vol_nan[..., 1] = np.nan
+        mv = MedicalVolume(vol_nan, np.eye(4), headers=headers)
+
+        mv2 = np.nansum(mv, axis=-1)
+        assert np.all(mv2 == np.nansum(mv.volume, axis=-1))
+        assert mv2.shape == mv.shape[:3]
+        mv2 = np.nansum(mv)
+        assert np.all(mv2 == np.nansum(mv.volume))
+        assert np.isscalar(mv2)
+
+        mv2 = np.nanmean(mv, axis=-1)
+        assert np.all(mv2 == np.nanmean(mv.volume, axis=-1))
+        assert mv2.shape == mv.shape[:3]
+        mv2 = np.nanmean(mv)
+        assert np.all(mv2 == np.nanmean(mv.volume))
+        assert np.isscalar(mv2)
+
+        mv2 = np.nanstd(mv, axis=-1)
+        assert np.all(mv2 == np.nanstd(mv.volume, axis=-1))
+        assert mv2.shape == mv.shape[:3]
+        mv2 = np.nanstd(mv)
+        assert np.all(mv2 == np.nanstd(mv.volume))
+        assert np.isscalar(mv2)
+
+        mv2 = np.nan_to_num(mv)
+        assert np.unique(mv2.volume).tolist() == [0, 1]
+        mv2 = np.nan_to_num(mv, copy=False)
+        assert id(mv2) == id(mv)
+
+        mv2 = np.nanmin(mv, axis=-1)
+        assert np.all(mv2 == np.nanmin(mv.volume, axis=-1))
+        assert mv2.shape == mv.shape[:3]
+        mv2 = np.nanmin(mv)
+        assert np.all(mv2 == np.nanmin(mv.volume))
+        assert np.isscalar(mv2)
+
+        mv2 = np.nanmax(mv, axis=-1)
+        assert np.all(mv2 == np.nanmax(mv.volume, axis=-1))
+        assert mv2.shape == mv.shape[:3]
+        mv2 = np.nanmax(mv)
+        assert np.all(mv2 == np.nanmax(mv.volume))
+        assert np.isscalar(mv2)
+
+        mv2 = np.nanargmin(mv, axis=-1)
+        assert np.all(mv2 == np.nanargmin(mv.volume, axis=-1))
+        assert mv2.shape == mv.shape[:3]
+        mv2 = np.nanargmin(mv)
+        assert np.all(mv2 == np.nanargmin(mv.volume))
+
+        mv2 = np.nanargmax(mv, axis=-1)
+        assert np.all(mv2 == np.nanargmax(mv.volume, axis=-1))
+        assert mv2.shape == mv.shape[:3]
+        mv2 = np.nanargmax(mv)
+        assert np.all(mv2 == np.nanargmax(mv.volume))
+
+        # Shaping functions
+        shape = (10, 20, 30, 2)
+        vol = np.ones(shape)
+        mv_a = MedicalVolume(vol, np.eye(4), headers=headers)
+        mv_b = MedicalVolume(vol * 2, np.eye(4), headers=headers)
+        mv_c = MedicalVolume(vol * 3, np.eye(4), headers=headers)
+
+        mv2 = np.stack([mv_a, mv_b, mv_c], axis=-1)
+        assert mv2.shape == (10, 20, 30, 2, 3)
+        assert mv2.headers is not None
+        assert np.all(mv2.volume == np.stack([mv_a.volume, mv_b.volume, mv_c.volume], axis=-1))
+        mv2 = np.stack([mv_a, mv_b, mv_c], axis=-2)
+        assert mv2.shape == (10, 20, 30, 3, 2)
+        with self.assertRaises(ValueError):
+            mv2 = np.stack([mv_a, mv_b, mv_c], axis=0)
+        with self.assertRaises(TypeError):
+            mv2 = np.stack([mv_a, mv_b, mv_c], axis=(-1,))
+
+        mv2 = np.expand_dims(mv_a, (-2, -3))
+        assert mv2.shape == (10, 20, 30, 1, 1, 2)
+        mv2 = np.expand_dims(mv_a, -1)
+        assert mv2.shape == (10, 20, 30, 2, 1)
+        with self.assertRaises(ValueError):
+            mv2 = np.expand_dims(mv_a, 0)
+
+        # Round
+        shape = (10, 20, 30, 2)
+        affine = np.concatenate([np.random.rand(3, 4), [[0, 0, 0, 1]]], axis=0)
+        mv = MedicalVolume(np.random.rand(*shape), affine, headers=headers)
+
+        mv2 = mv.round()
+        assert np.allclose(mv2.affine, affine)
+        assert np.unique(mv2.volume).tolist() == [0, 1]
+
+        mv2 = mv.round(affine=True)
+        assert np.unique(mv2.affine).tolist() == [0, 1]
+        assert np.unique(mv2.volume).tolist() == [0, 1]
 
     def test_hdf5(self):
         shape = (10, 20, 30)

--- a/tests/utils/test_fitting.py
+++ b/tests/utils/test_fitting.py
@@ -118,7 +118,7 @@ class TestCurveFitter(unittest.TestCase):
         popt, _ = fitter.fit(x, y)
         a_hat, b_hat = popt[..., 0], popt[..., 1]
         assert np.allclose(a_hat[:5].volume, 1.0) and np.all(np.isnan(a_hat[5:].volume))
-        assert np.allclose(b_hat, b)
+        assert np.allclose(b_hat.volume, b)
 
     def test_out_ufuncs(self):
         shape = (10, 10, 20)
@@ -132,19 +132,19 @@ class TestCurveFitter(unittest.TestCase):
         popt, _ = fitter.fit(x, y)
         a_hat, b_hat = popt[..., 0], popt[..., 1]
         assert np.allclose(a_hat.volume, ufunc(a))
-        assert np.allclose(b_hat, ufunc(b))
+        assert np.allclose(b_hat.volume, ufunc(b))
 
         fitter = CurveFitter(monoexponential, out_ufuncs=[None, ufunc])
         popt, _ = fitter.fit(x, y)
         a_hat, b_hat = popt[..., 0], popt[..., 1]
         assert np.allclose(a_hat.volume, a)
-        assert np.allclose(b_hat, ufunc(b))
+        assert np.allclose(b_hat.volume, ufunc(b))
 
         fitter = CurveFitter(monoexponential, out_ufuncs=[ufunc])
         popt, _ = fitter.fit(x, y)
         a_hat, b_hat = popt[..., 0], popt[..., 1]
         assert np.allclose(a_hat.volume, ufunc(a))
-        assert np.allclose(b_hat, b)
+        assert np.allclose(b_hat.volume, b)
 
     def test_nan_to_num(self):
         shape = (10, 10, 20)
@@ -179,7 +179,7 @@ class TestCurveFitter(unittest.TestCase):
         t_hat_cf = fitter.fit(x, y)[0][..., 1]
         t_hat_cf = np.round(t_hat_cf, decimals=8)
 
-        assert np.allclose(t_hat_mef.volume, t_hat_cf)
+        assert np.allclose(t_hat_mef.volume, t_hat_cf.volume)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
To facilitate numpy-like operations on MedicalVolumes, this PR adds support for standard numpy functions that make sense in the context of MedicalVolumes.

For the API, we chose to allow computing these functions on all dimensions (i.e. `axis=None`) or on non-spatial dimensions. Reductions cannot occur over a subset of spatial dimensions. If this is desired, we ask the user to operate directly on the NumPy array (i.e. `.volume` attribute)

Below, we divide these functions into a subset of types and list which functions of those types are supported:

- Boolean functions: `numpy.all`, `numpy.any`, `numpy.where`
- Statistics functions: `numpy.mean`, `numpy.sum`, `numpy.std`, `numpy.amin`, `numpy.amax`, `numpy.argmax`, `numpy.argmin`
- Rounding functions: `numpy.round`, `numpy.around`, `numpy.round_`
- NaN functions: `numpy.nanmean`, `numpy.nansum`, `numpy.nanstd`, `numpy.nan_to_num`
- Structuring functions (limited): `np.expand_dims`, `np.stack`, `np.concatenate`, `np.squeeze`

Because structuring `MedicalVolume` data is inherently linked to spatial coordinates of the data, structuring functions are limited in their scope. `np.stack` and `np.concatenate` require certain conditions to be met for the sequence of `MedicalVolume` data passed in. For more information, see the docstrings for these functions.