### PR TITLE
Add minimal dicom loading based on PatientOrientation

### DIFF
--- a/dosma/data_io/dicom_io.py
+++ b/dosma/data_io/dicom_io.py
@@ -38,159 +38,6 @@ __all__ = ["DicomReader", "DicomWriter"]
 TOTAL_NUM_ECHOS_KEY = (0x19, 0x107E)
 
 
-def __update_np_dtype__(arr: np.ndarray, bit_depth: int):
-    """Create copy of np_array with bit-depth and type specified here.
-
-    Note pydicom only supports writing dicoms with bit-depth 8/16 - only supports bit depths 8/16.
-
-    Args:
-        arr (np.ndarray): Numpy array to put into given bit depth.
-        bit_depth (int): Bit depth for writing dicom. Must be either `8` or `16`.
-
-    Returns:
-        np.ndarray: Copy of input np_array.
-
-    Raises:
-        ValueError: If `arr` out of bit-depth range.
-        TypeError: If `arr` contains float values out of supported float types.
-    """
-    assert bit_depth in [8, 16], "Only bit-depths of 8 and 16 are currently supported."
-    dtype_dict = {
-        8: [(np.int8, -128, 127), (np.uint8, 0, 255)],
-        16: [
-            (np.float16, -6.55e4, 6.55e4 - 1),
-            (np.int16, -2 ** 15, 2 ** 15),
-            (np.uint16, 0, 2 ** 16 - 1),
-        ],
-    }
-    supported_floats = [np.float16]
-    curr_min = np.min(arr)
-    curr_max = np.max(arr)
-    contains_float = (arr % 1 != 0).any()
-
-    dtypes = dtype_dict[bit_depth]
-
-    new_dtype = None
-    for dtype, dtype_min, dtype_max in dtypes:
-        if curr_min < dtype_min or curr_max > dtype_max:
-            continue
-        new_dtype = dtype
-        break
-    if not new_dtype:
-        raise ValueError(
-            "Cannot cast numpy array ({}) to bit-depth of {} bits".format(str(arr.dtype), bit_depth)
-        )
-
-    if contains_float and new_dtype not in supported_floats:
-        raise TypeError(
-            "Array contains float. Cannot cast to numpy array ({}) to {}".format(
-                str(arr.dtype), new_dtype
-            )
-        )
-
-    return arr.astype(new_dtype)
-
-
-def LPSplus_to_RASplus(headers: List[pydicom.FileDataset]):
-    """Convert from LPS+ orientation (default for DICOM) to RAS+ standardized orientation.
-
-    Args:
-        headers (list[pydicom.FileDataset]): Headers for DICOM files to reorient.
-            Files should correspond to single volume.
-
-    Returns:
-        np.ndarray: Affine matrix.
-    """
-    try:
-        im_dir = headers[0].ImageOrientationPatient
-    except AttributeError:
-        im_dir = _decode_inplane_direction(headers)
-        if im_dir is None:
-            raise RuntimeError("Could not determine in-plane directions from headers.")
-    in_plane_pixel_spacing = headers[0].PixelSpacing
-
-    orientation = np.zeros([3, 3])
-
-    # Determine vector for in-plane pixel directions (i, j).
-    i_vec, j_vec = (
-        np.asarray(im_dir[:3]).astype(np.float64),
-        np.asarray(im_dir[3:]).astype(np.float64),
-    )  # unique to pydicom, please revise if using different library to load dicoms
-    i_vec, j_vec = (
-        np.round(i_vec, AFFINE_DECIMAL_PRECISION),
-        np.round(j_vec, AFFINE_DECIMAL_PRECISION),
-    )
-    i_vec = i_vec * in_plane_pixel_spacing[0]
-    j_vec = j_vec * in_plane_pixel_spacing[1]
-
-    # Determine vector for through-plane pixel direction (k).
-    # Compute difference in patient position between consecutive headers.
-    # This is the preferred method to determine the k vector.
-    # If single header, take cross product between i/j vectors.
-    # These actions are done to avoid rounding errors that might result from float subtraction.
-    if len(headers) > 1:
-        k_vec = np.asarray(headers[1].ImagePositionPatient).astype(np.float64) - np.asarray(
-            headers[0].ImagePositionPatient
-        ).astype(np.float64)
-    else:
-        slice_thickness = headers[0].get("SliceThickness", 1.)
-        i_norm = 1 / np.linalg.norm(i_vec) * i_vec
-        j_norm = 1 / np.linalg.norm(j_vec) * j_vec
-        k_norm = np.cross(i_norm, j_norm)
-        k_vec = k_norm / np.linalg.norm(k_norm) * slice_thickness
-        if hasattr(headers[0], "SpacingBetweenSlices") and headers[0].SpacingBetweenSlices < 0:
-            k_vec *= -1
-    k_vec = np.round(k_vec, AFFINE_DECIMAL_PRECISION)
-
-    orientation[:3, :3] = np.stack([j_vec, i_vec, k_vec], axis=1)
-    scanner_origin = headers[0].get("ImagePositionPatient", np.zeros((3,)))
-    scanner_origin = np.asarray(scanner_origin).astype(np.float64)
-    scanner_origin = np.round(scanner_origin, SCANNER_ORIGIN_DECIMAL_PRECISION)
-
-    affine = np.zeros([4, 4])
-    affine[:3, :3] = orientation
-    affine[:3, 3] = scanner_origin
-    affine[:2, :] = -1 * affine[:2, :]
-    affine[3, 3] = 1
-
-    affine[affine == 0] = 0
-
-    return affine
-
-
-def _write_dicom_file(np_slice: np.ndarray, header: pydicom.FileDataset, file_path: str):
-    """Replace data in header with 2D numpy array and write to `file_path`.
-
-    Args:
-        np_slice (np.ndarray): 2D slice to encode in dicom file.
-        header (pydicom.FileDataset): DICOM header.
-        file_path: File path to write to.
-    """
-    # Deep copy required in case headers are shared.
-    header = copy.deepcopy(header)
-    expected_dimensions = header.Rows, header.Columns
-    assert (
-        np_slice.shape == expected_dimensions
-    ), "In-plane dimension mismatch - expected shape {}, got {}".format(
-        str(expected_dimensions), str(np_slice.shape)
-    )
-
-    np_slice_bytes = np_slice.tobytes()
-    bit_depth = int(len(np_slice_bytes) / (np_slice.shape[0] * np_slice.shape[1]) * 8)
-    if bit_depth != header.BitsAllocated:
-        np_slice = __update_np_dtype__(np_slice, header.BitsAllocated)
-        np_slice_bytes = np_slice.tobytes()
-        bit_depth = int(len(np_slice_bytes) / (np_slice.shape[0] * np_slice.shape[1]) * 8)
-
-    assert bit_depth == header.BitsAllocated, "Bit depth mismatch: Expected {:d} got {:d}".format(
-        header.BitsAllocated, bit_depth
-    )
-
-    header.PixelData = np_slice_bytes
-
-    header.save_as(file_path)
-
-
 class DicomReader(DataReader):
     """A class for reading DICOM files.
     """
@@ -313,7 +160,7 @@ class DicomReader(DataReader):
                 continue
             arr = np.stack(dd["arr"], axis=-1)
 
-            affine = LPSplus_to_RASplus(headers)
+            affine = to_RAS_affine(headers)
 
             vol = MedicalVolume(arr, affine, headers=headers)
             vols.append(vol)
@@ -430,6 +277,73 @@ class DicomWriter(DataWriter):
                 _write_dicom_file(volume_arr[..., s], headers[s], filepaths[s])
 
 
+def to_RAS_affine(headers: List[pydicom.FileDataset]):
+    """Convert from LPS+ orientation (default for DICOM) to RAS+ standardized orientation.
+
+    Args:
+        headers (list[pydicom.FileDataset]): Headers for DICOM files to reorient.
+            Files should correspond to single volume.
+
+    Returns:
+        np.ndarray: Affine matrix.
+    """
+    try:
+        im_dir = headers[0].ImageOrientationPatient
+    except AttributeError:
+        im_dir = _decode_inplane_direction(headers)
+        if im_dir is None:
+            raise RuntimeError("Could not determine in-plane directions from headers.")
+    in_plane_pixel_spacing = headers[0].PixelSpacing
+
+    orientation = np.zeros([3, 3])
+
+    # Determine vector for in-plane pixel directions (i, j).
+    i_vec, j_vec = (
+        np.asarray(im_dir[:3]).astype(np.float64),
+        np.asarray(im_dir[3:]).astype(np.float64),
+    )  # unique to pydicom, please revise if using different library to load dicoms
+    i_vec, j_vec = (
+        np.round(i_vec, AFFINE_DECIMAL_PRECISION),
+        np.round(j_vec, AFFINE_DECIMAL_PRECISION),
+    )
+    i_vec = i_vec * in_plane_pixel_spacing[0]
+    j_vec = j_vec * in_plane_pixel_spacing[1]
+
+    # Determine vector for through-plane pixel direction (k).
+    # Compute difference in patient position between consecutive headers.
+    # This is the preferred method to determine the k vector.
+    # If single header, take cross product between i/j vectors.
+    # These actions are done to avoid rounding errors that might result from float subtraction.
+    if len(headers) > 1:
+        k_vec = np.asarray(headers[1].ImagePositionPatient).astype(np.float64) - np.asarray(
+            headers[0].ImagePositionPatient
+        ).astype(np.float64)
+    else:
+        slice_thickness = headers[0].get("SliceThickness", 1.0)
+        i_norm = 1 / np.linalg.norm(i_vec) * i_vec
+        j_norm = 1 / np.linalg.norm(j_vec) * j_vec
+        k_norm = np.cross(i_norm, j_norm)
+        k_vec = k_norm / np.linalg.norm(k_norm) * slice_thickness
+        if hasattr(headers[0], "SpacingBetweenSlices") and headers[0].SpacingBetweenSlices < 0:
+            k_vec *= -1
+    k_vec = np.round(k_vec, AFFINE_DECIMAL_PRECISION)
+
+    orientation[:3, :3] = np.stack([j_vec, i_vec, k_vec], axis=1)
+    scanner_origin = headers[0].get("ImagePositionPatient", np.zeros((3,)))
+    scanner_origin = np.asarray(scanner_origin).astype(np.float64)
+    scanner_origin = np.round(scanner_origin, SCANNER_ORIGIN_DECIMAL_PRECISION)
+
+    affine = np.zeros([4, 4])
+    affine[:3, :3] = orientation
+    affine[:3, 3] = scanner_origin
+    affine[:2, :] = -1 * affine[:2, :]
+    affine[3, 3] = 1
+
+    affine[affine == 0] = 0
+
+    return affine
+
+
 def _decode_inplane_direction(headers: Sequence[pydicom.FileDataset]):
     """Helper function to decode in-plane direction from header(s).
 
@@ -469,7 +383,7 @@ def _format_volume_to_header(volume: MedicalVolume) -> MedicalVolume:
     headers = volume.headers()
     assert headers.shape == (1, 1, volume.shape[2])
 
-    affine = LPSplus_to_RASplus(headers.flatten())
+    affine = to_RAS_affine(headers.flatten())
     orientation = stdo.orientation_nib_to_standard(nib.aff2axcodes(affine))
 
     # Currently do not support mismatch in scanner_origin.
@@ -483,3 +397,89 @@ def _format_volume_to_header(volume: MedicalVolume) -> MedicalVolume:
     volume = volume.reformat(orientation)
     assert volume.headers().shape == (1, 1, volume.shape[2])
     return volume
+
+
+def _write_dicom_file(np_slice: np.ndarray, header: pydicom.FileDataset, file_path: str):
+    """Replace data in header with 2D numpy array and write to `file_path`.
+
+    Args:
+        np_slice (np.ndarray): 2D slice to encode in dicom file.
+        header (pydicom.FileDataset): DICOM header.
+        file_path: File path to write to.
+    """
+    # Deep copy required in case headers are shared.
+    header = copy.deepcopy(header)
+    expected_dimensions = header.Rows, header.Columns
+    assert (
+        np_slice.shape == expected_dimensions
+    ), "In-plane dimension mismatch - expected shape {}, got {}".format(
+        str(expected_dimensions), str(np_slice.shape)
+    )
+
+    np_slice_bytes = np_slice.tobytes()
+    bit_depth = int(len(np_slice_bytes) / (np_slice.shape[0] * np_slice.shape[1]) * 8)
+    if bit_depth != header.BitsAllocated:
+        np_slice = _update_np_dtype(np_slice, header.BitsAllocated)
+        np_slice_bytes = np_slice.tobytes()
+        bit_depth = int(len(np_slice_bytes) / (np_slice.shape[0] * np_slice.shape[1]) * 8)
+
+    assert bit_depth == header.BitsAllocated, "Bit depth mismatch: Expected {:d} got {:d}".format(
+        header.BitsAllocated, bit_depth
+    )
+
+    header.PixelData = np_slice_bytes
+
+    header.save_as(file_path)
+
+
+def _update_np_dtype(arr: np.ndarray, bit_depth: int):
+    """Create copy of np_array with bit-depth and type specified here.
+
+    Note pydicom only supports writing dicoms with bit-depth 8/16 - only supports bit depths 8/16.
+
+    Args:
+        arr (np.ndarray): Numpy array to put into given bit depth.
+        bit_depth (int): Bit depth for writing dicom. Must be either `8` or `16`.
+
+    Returns:
+        np.ndarray: Copy of input np_array.
+
+    Raises:
+        ValueError: If `arr` out of bit-depth range.
+        TypeError: If `arr` contains float values out of supported float types.
+    """
+    assert bit_depth in [8, 16], "Only bit-depths of 8 and 16 are currently supported."
+    dtype_dict = {
+        8: [(np.int8, -128, 127), (np.uint8, 0, 255)],
+        16: [
+            (np.float16, -6.55e4, 6.55e4 - 1),
+            (np.int16, -2 ** 15, 2 ** 15),
+            (np.uint16, 0, 2 ** 16 - 1),
+        ],
+    }
+    supported_floats = [np.float16]
+    curr_min = np.min(arr)
+    curr_max = np.max(arr)
+    contains_float = (arr % 1 != 0).any()
+
+    dtypes = dtype_dict[bit_depth]
+
+    new_dtype = None
+    for dtype, dtype_min, dtype_max in dtypes:
+        if curr_min < dtype_min or curr_max > dtype_max:
+            continue
+        new_dtype = dtype
+        break
+    if not new_dtype:
+        raise ValueError(
+            "Cannot cast numpy array ({}) to bit-depth of {} bits".format(str(arr.dtype), bit_depth)
+        )
+
+    if contains_float and new_dtype not in supported_floats:
+        raise TypeError(
+            "Array contains float. Cannot cast to numpy array ({}) to {}".format(
+                str(arr.dtype), new_dtype
+            )
+        )
+
+    return arr.astype(new_dtype)

--- a/dosma/data_io/med_volume.py
+++ b/dosma/data_io/med_volume.py
@@ -499,8 +499,19 @@ class MedicalVolume(NDArrayOperatorsMixin):
         return img
 
     def headers(self, flatten=False):
-        """Returns headers"""
-        if flatten:
+        """Returns headers.
+
+        If headers exist, they are currently stored as an array of
+        pydicom dataset headers, though this is subject to change.
+
+        Args:
+            flatten (bool, optional): If ``True``, flattens header array
+                before returning.
+
+        Returns:
+            Optional[ndarray[pydicom.dataset.FileDataset]]: Array of headers (if they exist).
+        """
+        if flatten and self._headers is not None:
             return self._headers.flatten()
         return self._headers
 

--- a/dosma/data_io/orientation.py
+++ b/dosma/data_io/orientation.py
@@ -292,6 +292,8 @@ def to_affine(
 
         return input
 
+    if len(orientation) == 2:
+        orientation = _infer_orientation(orientation)
     __check_orientation__(orientation)
     spacing = _format_numbers(spacing, 1, "spacing", len(orientation))
     origin = _format_numbers(origin, 0, "origin", len(orientation))
@@ -310,3 +312,22 @@ def to_affine(
     affine[:3, 3] = np.asarray(origin)
 
     return affine
+
+
+def _infer_orientation(orientation):
+    """Infer 3-length orientation from 2-length orientation.
+
+    Args:
+        orientation: The incomplete orientation.
+    
+    Returns:
+        tuple[str, str, str]: Standard orientation.
+    """
+    idxs = set([__ORIENTATIONS_TO_AXIS_ID__[k] for k in orientation])
+    if len(orientation) != 2 or len(idxs) != 2:
+        raise ValueError(
+            "`orientation` must be an incomplete orientation that encodes orthogonal directions"
+        )
+
+    missing_ornt = [k for k, v in __ORIENTATIONS_TO_AXIS_ID__.items() if v not in idxs][0]
+    return tuple(orientation) + (missing_ornt,)

--- a/dosma/data_io/orientation.py
+++ b/dosma/data_io/orientation.py
@@ -58,6 +58,10 @@ For details on how the affine matrix is used for reformatting see
 :class:`dosma.data_io.MedicalVolume`.
 
 """
+from typing import Sequence, Union
+
+import nibabel.orientations as nibo
+import numpy as np
 
 __all__ = [
     "get_transpose_inds",
@@ -231,3 +235,78 @@ def orientation_standard_to_nib(orientation):
     for symb in orientation:
         nib_orientation.append(symb[1])
     return tuple(nib_orientation)
+
+
+def to_affine(
+    orientation,
+    spacing: Sequence[Union[int, float]] = None,
+    origin: Sequence[Union[int, float]] = None,
+):
+    """Convert orientation, spacing, and origin data into affine matrix.
+
+    Args:
+        orientation (Sequence[str]): Image orientation in the standard orientation format
+            (e.g. ``("LR", "AP", "SI")``).
+        spacing (int(s) | float(s)): Number(s) corresponding to pixel spacing of each direction.
+            If a single value, same pixel spacing is used for all directions.
+            If sequence is less than length of ``orientation``, remaining direction have unit
+            spacing (i.e. ``1``). Defaults to unit spacing ``(1, 1, 1)``
+        origin (int(s) | float(s)): The ``(x0, y0, z0)`` origin for the scan.
+            If a single value, same origin is used for all directions.
+            If sequence is less than length of ``orientation``, remaining direction have standard
+            origin (i.e. ``0``). Defaults to ``(0, 0, 0)``
+
+    Returns:
+        ndarray: A 4x4 ndarray representing the affine matrix.
+
+    Examples:
+        >>> to_affine(("SI", "AP", "RL"), spacing=(0.5, 0.5, 1.5), origin=(10, 20, 0))
+        array([[-0. , -0. , -1.5,  10. ],
+               [-0. , -0.5, -0. ,  20. ],
+               [-0.5, -0. , -0. ,  30. ],
+               [ 0. ,  0. ,  0. ,   1. ]])
+
+    Note:
+        This method assumes all direction follow the standard principal directions in the normative
+        patient orientation. Moving along one direction of the array only moves along one fo the
+        normative directions.
+    """
+
+    def _format_numbers(input, default_val, name, expected_num):
+        """Formats (sequence of) numbers (spacing, origin) into standard 3-length tuple."""
+        if input is None:
+            return (default_val,) * expected_num
+        if isinstance(input, (int, float)):
+            return (input,) * expected_num
+
+        if not isinstance(input, (np.ndarray, Sequence)) or len(input) > expected_num:
+            raise ValueError(
+                f"`{name}` must be a real number or sequence (length<={expected_num}) "
+                f"of real numbers. Got {input}"
+            )
+        input = tuple(input)
+
+        if len(input) < expected_num:
+            input += (default_val,) * (expected_num - len(input))
+        assert len(input) == expected_num
+
+        return input
+
+    __check_orientation__(orientation)
+    spacing = _format_numbers(spacing, 1, "spacing", len(orientation))
+    origin = _format_numbers(origin, 0, "origin", len(orientation))
+
+    affine = np.eye(4)
+    start_ornt = nibo.io_orientation(affine)
+    end_ornt = nibo.axcodes2ornt(orientation_standard_to_nib(orientation))
+    ornt = nibo.ornt_transform(start_ornt, end_ornt)
+
+    transpose_idxs = ornt[:, 0].astype(np.int)
+    flip_idxs = ornt[:, 1]
+
+    affine[:3] = affine[:3][transpose_idxs]
+    affine[:3] *= flip_idxs[..., np.newaxis]
+    affine[:3, :3] *= np.asarray(spacing)
+    affine[:3, 3] = np.asarray(origin)
+
+    return affine

--- a/dosma/data_io/orientation.py
+++ b/dosma/data_io/orientation.py
@@ -319,7 +319,7 @@ def _infer_orientation(orientation):
 
     Args:
         orientation: The incomplete orientation.
-    
+
     Returns:
         tuple[str, str, str]: Standard orientation.
     """

--- a/tests/data_io/test_io.py
+++ b/tests/data_io/test_io.py
@@ -7,7 +7,7 @@ import unittest
 import numpy as np
 import pydicom
 
-from dosma.data_io.dicom_io import DicomReader, DicomWriter, LPSplus_to_RASplus
+from dosma.data_io.dicom_io import DicomReader, DicomWriter, to_RAS_affine
 from dosma.data_io.format_io import ImageDataFormat
 from dosma.data_io.med_volume import MedicalVolume
 from dosma.data_io.nifti_io import NiftiReader, NiftiWriter
@@ -404,11 +404,11 @@ class TestDicomIO(unittest.TestCase):
         header = ututils.build_dummy_headers(
             1, fields={"PatientOrientation": ["P", "F"], "PixelSpacing": [0.2, 0.5]}
         )
-        affine = LPSplus_to_RASplus(header)
+        affine = to_RAS_affine(header)
         mv = MedicalVolume(np.ones((10, 20, 30)), affine=affine)
         assert mv.orientation == ("SI", "AP", "LR")
-        assert mv.pixel_spacing == (0.5, 0.2, 1.)
-        assert mv.scanner_origin == (0., 0., 0.)
+        assert mv.pixel_spacing == (0.5, 0.2, 1.0)
+        assert mv.scanner_origin == (0.0, 0.0, 0.0)
 
 
 class TestInterIO(unittest.TestCase):

--- a/tests/data_io/test_io.py
+++ b/tests/data_io/test_io.py
@@ -7,7 +7,7 @@ import unittest
 import numpy as np
 import pydicom
 
-from dosma.data_io.dicom_io import DicomReader, DicomWriter
+from dosma.data_io.dicom_io import DicomReader, DicomWriter, LPSplus_to_RASplus
 from dosma.data_io.format_io import ImageDataFormat
 from dosma.data_io.med_volume import MedicalVolume
 from dosma.data_io.nifti_io import NiftiReader, NiftiWriter
@@ -397,6 +397,18 @@ class TestDicomIO(unittest.TestCase):
                 out = self.dr.load(out_path)[0]
 
                 assert out.is_identical(expected)
+
+    def test_special_affine(self):
+        """Test creation of affine matrix for special cases."""
+        # Patient orientation (useful for xray data).
+        header = ututils.build_dummy_headers(
+            1, fields={"PatientOrientation": ["P", "F"], "PixelSpacing": [0.2, 0.5]}
+        )
+        affine = LPSplus_to_RASplus(header)
+        mv = MedicalVolume(np.ones((10, 20, 30)), affine=affine)
+        assert mv.orientation == ("SI", "AP", "LR")
+        assert mv.pixel_spacing == (0.5, 0.2, 1.)
+        assert mv.scanner_origin == (0., 0., 0.)
 
 
 class TestInterIO(unittest.TestCase):

--- a/tests/data_io/test_med_volume.py
+++ b/tests/data_io/test_med_volume.py
@@ -93,7 +93,11 @@ class TestMedicalVolume(unittest.TestCase):
 
         volume = np.random.rand(10, 20, 30, 40)
         headers = ututils.build_dummy_headers(volume.shape[2:], {field: field_val})
+        mv_no_headers = MedicalVolume(volume, self._AFFINE)
         mv = MedicalVolume(volume, self._AFFINE, headers=headers)
+
+        assert mv_no_headers.headers() is None
+        assert mv_no_headers.headers(flatten=True) is None
 
         echo_time = mv.get_metadata(field)
         assert echo_time == field_val
@@ -409,7 +413,7 @@ class TestMedicalVolume(unittest.TestCase):
 
         mv2 = np.stack([mv_a, mv_b, mv_c], axis=-1)
         assert mv2.shape == (10, 20, 30, 2, 3)
-        assert mv2.headers is not None
+        assert mv2.headers() is not None
         assert np.all(mv2.volume == np.stack([mv_a.volume, mv_b.volume, mv_c.volume], axis=-1))
         mv2 = np.stack([mv_a, mv_b, mv_c], axis=-2)
         assert mv2.shape == (10, 20, 30, 3, 2)


### PR DESCRIPTION
This PR adds minimal support for loading DICOMs that do not have the ``ImageOrientationPatient``, ``ImagePositionPatient`` attributes, but have the ``PatientOrientation`` attribute (e.g. xrays).

When there is only one header file and the data has the ``PatientOrientation`` attribute, we convert the string directions to nominal direction vectors (`i`, `j`).

Changes:
- helper function `to_affine` to convert orientation, spacing, and origin information into nominal direction vectors
- renaming and reordering private helper functions for `DicomReader`
- bug fix: `headers` should return `None` when flattening