### PR TITLE
Bug fix: reshape headers for fitting to allow broadcasting

### DIFF
--- a/dosma/utils/fits.py
+++ b/dosma/utils/fits.py
@@ -74,6 +74,9 @@ class CurveFitter:
             replace *posinf* and *neginf* values with very large positive and negative values,
             respectively. See ``numpy.nan_to_num`` for more details.
         num_workers (int, optional): Maximum number of workers to use for fitting.
+        chunksize (int, optional): Size of chunks sent to worker processes when
+            ``num_workers > 0``. When ``show_pbar=True``, this defaults to the standard
+            value in :func:`tqdm.concurrent.process_map`.
         verbose (bool, optional): If `True`, show progress bar. Note this can increase runtime
             slightly when using multiple workers.
         kwargs: Keyword args for :func:`dosma.utils.fits.curve_fit`.
@@ -109,6 +112,7 @@ class CurveFitter:
         r2_threshold: float = "preferences",
         nan_to_num: float = None,
         num_workers: int = 0,
+        chunksize: int = None,
         verbose: bool = False,
         **kwargs,
     ):
@@ -156,6 +160,7 @@ class CurveFitter:
         self.r2_threshold = r2_threshold
         self.nan_to_num = nan_to_num
         self.num_workers = num_workers
+        self.chunksize = chunksize
         self.verbose = verbose
         self.kwargs = kwargs
 
@@ -251,6 +256,7 @@ class CurveFitter:
             p0=self.p0,
             show_pbar=self.verbose,
             num_workers=self.num_workers,
+            chunksize=self.chunksize,
             **self.kwargs,
         )
 
@@ -286,6 +292,7 @@ class CurveFitter:
             "r2_threshold",
             "nan_to_num",
             "num_workers",
+            "chunksize",
             "verbose",
         ]
         vals = [f"func={self._func_name}"]
@@ -436,6 +443,7 @@ def curve_fit(
     eps=1e-8,
     show_pbar=False,
     num_workers=0,
+    chunksize: int = None,
     **kwargs,
 ):
     """Use non-linear least squares to fit a function ``func`` to data.
@@ -463,6 +471,10 @@ def curve_fit(
         eps (float, optional): Epsilon for computing r-squared.
         show_pbar (bool, optional): If `True`, show progress bar. Note this can increase runtime
             slightly when using multiple workers.
+        num_workers (int, optional): Maximum number of workers to use for fitting.
+        chunksize (int, optional): Size of chunks sent to worker processes when
+            ``num_workers > 0``. When ``show_pbar=True``, this defaults to the standard
+            value in :func:`tqdm.concurrent.process_map`.
         kwargs: Keyword args for `scipy.optimize.curve_fit`.
     """
     if (get_device(x) != cpu_device) or (get_device(y) != cpu_device):
@@ -509,10 +521,12 @@ def curve_fit(
             r_squared.append(r2_)
     else:
         if show_pbar:
-            data = process_map(fitter, y.T, max_workers=num_workers)
+            tqdm_kwargs = {"chunksize": chunksize}
+            tqdm_kwargs = {k: v for k, v in tqdm_kwargs.items() if v is not None}
+            data = process_map(fitter, y.T, max_workers=num_workers, **tqdm_kwargs)
         else:
             with mp.Pool(num_workers) as p:
-                data = p.map(fitter, y.T)
+                data = p.map(fitter, y.T, chunksize=chunksize)
         popts, r_squared = [x[0] for x in data], [x[1] for x in data]
 
     return np.stack(popts, axis=0), np.asarray(r_squared)

--- a/tests/utils/test_fitting.py
+++ b/tests/utils/test_fitting.py
@@ -51,6 +51,11 @@ class TestCurveFit(unittest.TestCase):
         popt_mw, _ = curve_fit(monoexponential, x, ys, num_workers=util.num_workers())
         assert np.allclose(popt, popt_mw)
 
+        popt_mw, _ = curve_fit(
+            monoexponential, x, ys, num_workers=util.num_workers(), show_pbar=True
+        )
+        assert np.allclose(popt, popt_mw)
+
 
 class TestMonoExponentialFit(unittest.TestCase):
     def test_basic(self):

--- a/tests/utils/test_fitting.py
+++ b/tests/utils/test_fitting.py
@@ -22,6 +22,24 @@ def _generate_monoexp_data(shape=None, x=None, a=1.0, b=None):
     return x, y, b
 
 
+def _linear(x, a):
+    return a * x
+
+
+def _generate_linear_data(shape=None, x=None, a=None):
+    """Generate sample linear data.
+    ``a`` is randomly generated in interval [0.1, 1.1).
+    """
+    if a is None:
+        a = np.random.rand(*shape) + 0.1
+    else:
+        shape = a.shape
+    if x is None:
+        x = np.asarray([0.5, 1.0, 2.0, 4.0])
+    y = [MedicalVolume(_linear(t, a), affine=np.eye(4)) for t in x]
+    return x, y, a
+
+
 class TestCurveFit(unittest.TestCase):
     def test_multiple_workers(self):
         x = np.asarray([1, 2, 3, 4])
@@ -180,6 +198,34 @@ class TestCurveFitter(unittest.TestCase):
         t_hat_cf = np.round(t_hat_cf, decimals=8)
 
         assert np.allclose(t_hat_mef.volume, t_hat_cf.volume)
+
+    def test_headers(self):
+        """Test curve fitter does not fail with volumes with headers."""
+        x, y, b = _generate_monoexp_data((10, 10, 20, 4))
+        for idx, _y in enumerate(y):
+            _y._headers = util.build_dummy_headers(
+                (1, 1) + _y.shape[2:], fields={"EchoNumbers": idx}
+            )
+
+        fitter = CurveFitter(monoexponential)
+        popt, _ = fitter.fit(x, y)
+        a_hat, b_hat = popt[..., 0], popt[..., 1]
+
+        assert np.allclose(a_hat.volume, 1.0)
+        assert np.allclose(b_hat.volume, b)
+
+        # Test header with single parameter to fit
+        x, y, a = _generate_linear_data((10, 10, 20, 4))
+        for idx, _y in enumerate(y):
+            _y._headers = util.build_dummy_headers(
+                (1, 1) + _y.shape[2:], fields={"EchoNumbers": idx}
+            )
+
+        fitter = CurveFitter(_linear)
+        popt, _ = fitter.fit(x, y)
+        a_hat = popt[..., 0]
+
+        assert np.allclose(a_hat.volume, a)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When assigning headers to the quantitative fit volumes, the headers must be of the appropriate size to allow standard broadcasting. 

Changes:
- Add proper reshaping of headers in `CurveFitter`
- Add `chunksize` argument for multiprocessing