### PR TITLE
Add np.clip support and simple array accessor

### DIFF
--- a/dosma/data_io/med_volume.py
+++ b/dosma/data_io/med_volume.py
@@ -590,6 +590,20 @@ class MedicalVolume(NDArrayOperatorsMixin):
         return mean_np(self, axis=axis, dtype=dtype, keepdims=keepdims, where=where)
 
     @property
+    def A(self):
+        """The pixel array.
+
+        Same as ``self.volume``.
+
+        Examples:
+            >>> mv = MedicalVolume([[[1,2],[3,4]]], np.eye(4))
+            >>> mv.A
+            array([[[1, 2],
+                    [3, 4]]])
+        """
+        return self.volume
+
+    @property
     def volume(self):
         """ndarray: 3D ndarray representing volume values."""
         return self._volume

--- a/dosma/data_io/med_volume.py
+++ b/dosma/data_io/med_volume.py
@@ -1100,6 +1100,36 @@ def around(x, decimals=0, affine=False):
     return x._partial_clone(volume=np.around(x.volume, decimals=decimals), affine=affine)
 
 
+@implements(np.clip)
+def clip(x, x_min, x_max, **kwargs):
+    """Clip the values in the array.
+
+    Same as applying :func:`np.clip` on ``x.volume``.
+    Only one of ``x_min`` or ``x_max`` can be ``None``.
+
+    Args:
+        x (MedicalVolume): Medical image to clip.
+        x_min (array-like or ``MedicalVolume``): Minimum value.
+            If ``None``, clipping is not performed on this edge.
+        x_max (array-like or ``MedicalVolume``): Maximum value.
+            If ``None``, clipping is not performed on this edge.
+        kwargs: Optional keyword arguments, see :func:`np.clip`.
+
+    Returns:
+        MedicalVolume: The clipped medical image.
+
+    Note:
+        The ``out`` positional argument is not currently supported.
+    """
+    if isinstance(x_min, MedicalVolume):
+        x_min = x_min.A
+    if isinstance(x_max, MedicalVolume):
+        x_max = x_max.A
+
+    arr = np.clip(x.A, x_min, x_max, **kwargs)
+    return x._partial_clone(volume=arr)
+
+
 @implements(np.stack)
 def stack(xs, axis: int = -1):
     """Stack medical images across non-spatial dimensions.

--- a/tests/data_io/test_med_volume.py
+++ b/tests/data_io/test_med_volume.py
@@ -396,6 +396,13 @@ class TestMedicalVolume(unittest.TestCase):
         assert np.unique(mv2.affine).tolist() == [0, 1]
         assert np.unique(mv2.volume).tolist() == [0, 1]
 
+        # Clip
+        shape = (10, 20, 30)
+        mv = MedicalVolume(np.random.rand(*shape), np.eye(4))
+
+        mv2 = np.clip(mv, 0.4, 0.6)
+        assert np.all((mv2.volume >= 0.4) & (mv2.volume <= 0.6))
+
     def test_numpy_shaping(self):
         """Test numpy shaping functions (stack, concatenate, etc.)."""
         shape = (10, 20, 30, 2)


### PR DESCRIPTION
Changes:
- MedicalVolume supports `np.clip`
- `MedicalVolume.A` is an alias for `MedicalVolume.volume`