### PR TITLE
Polish curve_fit, support better dicom reader/writer init, default for get metadata

### DIFF
--- a/dosma/data_io/dicom_io.py
+++ b/dosma/data_io/dicom_io.py
@@ -77,8 +77,8 @@ class DicomReader(DataReader):
         path,
         include: Union[str, Sequence[str]] = None,
         exclude: Union[str, Sequence[str]] = None,
-        ignore_ext: bool = False,
         ignore_hidden: bool = True,
+        ignore_ext: bool = np._NoValue,
     ):
         """Get dicom files from directory.
 
@@ -93,7 +93,7 @@ class DicomReader(DataReader):
             ignore_ext (bool, optional): If ``True``, ignore extension (`.dcm`)
                 when loading dicoms from directory.
             ignore_hidden (bool, optional): If ``True``, ignores hidden
-                files (files starting with ``"."``).
+                files (files starting with ``"."``). Defaults to ``self.ignore_ext``.
 
         Returns:
             List[str]: Dicom file paths (in natsort order)
@@ -103,6 +103,8 @@ class DicomReader(DataReader):
         """
         if not os.path.isdir(path):
             raise NotADirectoryError("`path` must be path to directory with dicoms.")
+
+        ignore_ext = ignore_ext if ignore_ext != np._NoValue else self.ignore_ext
 
         include = _wrap_as_tuple(include, default=())
         exclude = _wrap_as_tuple(exclude, default=())
@@ -174,7 +176,7 @@ class DicomReader(DataReader):
 
         if isinstance(path, str):
             if os.path.isdir(path):
-                lstFilesDCM = self.get_files(path, ignore_ext=ignore_ext, ignore_hidden=True)
+                lstFilesDCM = self.get_files(path, ignore_hidden=True, ignore_ext=ignore_ext)
             elif os.path.isfile(path):
                 lstFilesDCM = [path]
             else:

--- a/dosma/data_io/dicom_io.py
+++ b/dosma/data_io/dicom_io.py
@@ -41,6 +41,31 @@ TOTAL_NUM_ECHOS_KEY = (0x19, 0x107E)
 
 class DicomReader(DataReader):
     """A class for reading DICOM files.
+
+    Attributes:
+        num_workers (int, optional): Number of workers to use for loading.
+        verbose (bool, optional): If ``True``, show loading progress bar.
+        group_by (``str``(s) or ``int``(s), optional): DICOM attribute(s) used
+            to group dicoms. This can be the attribute tag name (str) or tag
+            number (int).
+        sort_by (``str``(s) or ``int``(s), optional): DICOM attribute(s) used
+            to sort dicoms. This sorting is done after sorting files in alphabetical
+            order.
+        ignore_ext (bool, optional): If ``True``, ignore extension (``".dcm"``)
+            when loading dicoms from directory.
+
+    Examples:
+        >>> # Load single dicom
+        >>> dr = DicomReader()
+        >>> mv = dr.load("/path/to/dicom/file", group_by=None)[0]
+
+        >>> # Load multi-echo MRI data
+        >>> dr = DicomReader(num_workers=0, verbose=True)
+        >>> mvs = dr.load("/dicoms/directory", group_by="EchoTime", sort_by="InstanceNumber")
+
+        >>> # Use the same loader for multiple multi-echo MRI scans
+        >>> dr = DicomReader(group_by="EchoTime", sort_by="InstanceNumber")
+        >>> scans = [dr.load(dcm_dir) for dcm_dir in ["/dicom/dir1", "/dicom/dir2", "/dicom/dir3"]]
     """
 
     data_format_code = ImageDataFormat.dicom
@@ -250,6 +275,22 @@ class DicomReader(DataReader):
 
 class DicomWriter(DataWriter):
     """A class for writing volumes in DICOM format.
+
+    Attributes:
+        num_workers (int, optional): Number of workers to use for writing.
+        verbose (bool, optional): If ``True``, show writing progress bar.
+        fname_fmt (str, optional): Formatting string for filenames.
+        sort_by (``str``(s) or ``int``(s), optional): DICOM attribute(s) used
+            to define ordering of slices prior to writing. If not specified, this ordering
+            will be defined by the order of blocks in ``volume``.
+
+    Examples:
+        >>> # Save MedicalVolume mv
+        >>> dw = DicomWriter()
+        >>> dw.save(mv, "/path/to/save/folder")
+
+        >>> dw = DicomWriter(fname_fmt="I%05d.dcm", sort_by="InstanceNumber")
+        >>> dw.save(mv, "/path/to/save/folder")
     """
 
     data_format_code = ImageDataFormat.dicom

--- a/dosma/data_io/dicom_io.py
+++ b/dosma/data_io/dicom_io.py
@@ -45,13 +45,32 @@ class DicomReader(DataReader):
 
     data_format_code = ImageDataFormat.dicom
 
-    def __init__(self, num_workers: int = 0, verbose: bool = False):
+    def __init__(
+        self,
+        num_workers: int = 0,
+        verbose: bool = False,
+        group_by: Union[str, int, Sequence[Union[str, int]]] = "EchoNumbers",
+        sort_by: Union[str, int, Sequence[Union[str, int]]] = None,
+        ignore_ext: bool = False,
+    ):
         """
         Args:
             num_workers (int, optional): Number of workers to use for loading.
+            verbose (bool, optional): If ``True``, show loading progress bar.
+            group_by (``str``(s) or ``int``(s), optional): DICOM attribute(s) used
+                to group dicoms. This can be the attribute tag name (str) or tag
+                number (int).
+            sort_by (``str``(s) or ``int``(s), optional): DICOM attribute(s) used
+                to sort dicoms. This sorting is done after sorting files in alphabetical
+                order.
+            ignore_ext (bool, optional): If ``True``, ignore extension (``".dcm"``)
+                when loading dicoms from directory.
         """
         self.num_workers = num_workers
         self.verbose = verbose
+        self.group_by = group_by
+        self.sort_by = sort_by
+        self.ignore_ext = ignore_ext
 
     def get_files(
         self,
@@ -112,9 +131,9 @@ class DicomReader(DataReader):
     def load(
         self,
         path: Union[str, Sequence[str]],
-        group_by: Union[str, int, Sequence[Union[str, int]]] = "EchoNumbers",
-        sort_by: Union[str, int, Sequence[Union[str, int]]] = None,
-        ignore_ext: bool = False,
+        group_by: Union[str, int, Sequence[Union[str, int]]] = np._NoValue,
+        sort_by: Union[str, int, Sequence[Union[str, int]]] = np._NoValue,
+        ignore_ext: bool = np._NoValue,
     ):
         """Load dicoms into ``MedicalVolume``s grouped by ``group_by`` tag(s).
 
@@ -126,12 +145,12 @@ class DicomReader(DataReader):
             path (`str(s)`): Directory with dicom files or dicom file(s).
             group_by (``str``(s) or ``int``(s), optional): DICOM attribute(s) used
                 to group dicoms. This can be the attribute tag name (str) or tag
-                number (int). Defaults to ``EchoNumbers``.
+                number (int). Defaults to ``self.group_by``.
             sort_by (``str``(s) or ``int``(s), optional): DICOM attribute(s) used
                 to sort dicoms. This sorting is done after sorting files in alphabetical
-                order.
+                order. Defaults to ``self.sort_by``.
             ignore_ext (bool, optional): If ``True``, ignore extension (``".dcm"``)
-                when loading dicoms from directory.
+                when loading dicoms from directory. Defaults to ``self.ignore_ext``.
 
         Returns:
             list[MedicalVolume]: Different volumes grouped by the `group_by` DICOM tag.
@@ -146,6 +165,10 @@ class DicomReader(DataReader):
             For best performance, specify ``group_by`` based on the attribute(s) differentiating
             different volumes in the scan.
         """
+        group_by = group_by if group_by != np._NoValue else self.group_by
+        sort_by = sort_by if sort_by != np._NoValue else self.sort_by
+        ignore_ext = ignore_ext if ignore_ext != np._NoValue else self.ignore_ext
+
         group_by = _wrap_as_tuple(group_by, default=())
         sort_by = _wrap_as_tuple(sort_by, default=())
 
@@ -229,20 +252,35 @@ class DicomWriter(DataWriter):
 
     data_format_code = ImageDataFormat.dicom
 
-    def __init__(self, num_workers: int = 0, verbose: bool = False):
+    def __init__(
+        self,
+        num_workers: int = 0,
+        verbose: bool = False,
+        fname_fmt: str = None,
+        sort_by: Union[str, int, Sequence[Union[str, int]]] = None,
+    ):
         """
         Args:
             num_workers (int, optional): Number of workers to use for writing.
+            verbose (bool, optional): If ``True``, show writing progress bar.
+            fname_fmt (str, optional): Formatting string for filenames. Must contain ``%d``,
+                which correspopnds to slice number. Defaults to
+                ``"I%0{max(4, ceil(log10(num_slices)))}d.dcm"`` (e.g. ``"I0001.dcm"``).
+            sort_by (``str``(s) or ``int``(s), optional): DICOM attribute(s) used
+                to define ordering of slices prior to writing. If not specified, this ordering
+                will be defined by the order of blocks in ``volume``.
         """
         self.num_workers = num_workers
         self.verbose = verbose
+        self.fname_fmt = fname_fmt
+        self.sort_by = sort_by
 
     def save(
         self,
         volume: MedicalVolume,
         dir_path: str,
-        fname_fmt: str = None,
-        sort_by: Union[str, int, Sequence[Union[str, int]]] = None,
+        fname_fmt: str = np._NoValue,
+        sort_by: Union[str, int, Sequence[Union[str, int]]] = np._NoValue,
     ):
         """Save `medical volume` in dicom format.
 
@@ -262,16 +300,19 @@ class DicomWriter(DataWriter):
             dir_path: Directory path to store dicom files. Dicoms are stored in directories,
                 as multiple files are needed to store the volume.
             fname_fmt (str, optional): Formatting string for filenames. Must contain ``%d``,
-                which correspopnds to slice number. Defaults to
-                ``"I%0{max(4, ceil(log10(num_slices)))}d.dcm"`` (e.g. ``"I0001.dcm"``).
+                which correspopnds to slice number. Defaults to ``self.fname_fmt``.
             sort_by (``str``(s) or ``int``(s), optional): DICOM attribute(s) used
-                to define ordering of slices prior to writing. If not specified, this ordering
-                will be defined by the order of blocks in ``volume``.
+                to define ordering of slices prior to writing. If ``None``, this ordering
+                will be defined by the order of blocks in ``volume``. Defaults to
+                ``self.sort_by``.
 
         Raises:
             ValueError: If `im` does not have initialized headers. Or if `im` was flipped across
                 any axis. Flipping changes scanner origin, which is currently not handled.
         """
+        fname_fmt = fname_fmt if fname_fmt != np._NoValue else self.fname_fmt
+        sort_by = sort_by if sort_by != np._NoValue else self.sort_by
+
         # Get orientation indicated by headers.
         headers = volume.headers()
         if headers is None:

--- a/dosma/utils/fits.py
+++ b/dosma/utils/fits.py
@@ -503,7 +503,6 @@ def curve_fit(
         p0=p0,
         ftol=ftol,
         eps=eps,
-        show_pbar=show_pbar,
         nparams=nparams,
         **kwargs,
     )
@@ -532,21 +531,9 @@ def curve_fit(
     return np.stack(popts, axis=0), np.asarray(r_squared)
 
 
-def _curve_fit(
-    y,
-    x,
-    func,
-    y_bounds=None,
-    p0=None,
-    maxfev=100,
-    ftol=1e-5,
-    eps=1e-8,
-    show_pbar=False,
-    nparams=None,
-    **kwargs,
-):
+def _curve_fit(y, x, func, y_bounds=None, p0=None, ftol=1e-5, eps=1e-8, nparams=None, **kwargs):
     def _fit_internal(_x, _y):
-        popt, _ = sop.curve_fit(func, _x, _y, p0=p0, maxfev=maxfev, ftol=ftol, **kwargs)
+        popt, _ = sop.curve_fit(func, _x, _y, p0=p0, ftol=ftol, **kwargs)
 
         residuals = _y - func(_x, *popt)
         ss_res = np.sum(residuals ** 2)

--- a/tests/data_io/test_io.py
+++ b/tests/data_io/test_io.py
@@ -453,6 +453,26 @@ class TestDicomIO(unittest.TestCase):
 
         assert e1.is_identical(e1_expected)
 
+    def test_init_params(self):
+        """Test reading/writing works with passing values to constructor."""
+        dp = ututils.get_scan_dirpath("qdess")
+        # Echo 1 only
+        fp = ututils.get_read_paths(dp, self.data_format)[0]
+
+        e1_expected = self.dr.load(fp, group_by=None, sort_by="InstanceNumber", ignore_ext=False)[0]
+        dr = DicomReader(group_by=None, sort_by="InstanceNumber", ignore_ext=False)
+        e1 = dr.load(fp)[0]
+        e1_expected.orientation
+
+        assert e1.is_identical(e1_expected)
+
+        write_path = os.path.join(ututils.get_write_path(dp, self.data_format), "out-init-params")
+        dw = DicomWriter(fname_fmt="I%05d.dcm", sort_by="InstanceNumber")
+        dw.save(e1_expected, write_path, sort_by="InstanceNumber")
+
+        files = [_f for _f in os.listdir(write_path) if _f.endswith(".dcm")]
+        assert len(files) == e1_expected.shape[-1]
+
 
 class TestInterIO(unittest.TestCase):
     nr = NiftiReader()

--- a/tests/data_io/test_med_volume.py
+++ b/tests/data_io/test_med_volume.py
@@ -99,6 +99,10 @@ class TestMedicalVolume(unittest.TestCase):
         assert mv_no_headers.headers() is None
         assert mv_no_headers.headers(flatten=True) is None
 
+        with self.assertRaises(ValueError):
+            mv.get_metadata("foobar")
+        assert mv.get_metadata("foobar", default=0) == 0
+
         echo_time = mv.get_metadata(field)
         assert echo_time == field_val
 


### PR DESCRIPTION
- Add init params to `DicomReader` - ``group_by``, ``sort_by``, ``ignore_ext``
- Add init params to `DicomWriter` - ``fname_fmt``, ``sort_by``
- Add `defaults` argument to `MedicalVolume.get_metadata()`

Minor Changes:
- Remove `show_pbar` from `_curve_fit`, which does not use the pbar