### PR TITLE
Persist keras models and add state_dicts to readers/writers

### DIFF
--- a/dosma/data_io/dicom_io.py
+++ b/dosma/data_io/dicom_io.py
@@ -20,7 +20,7 @@ import multiprocessing as mp
 import os
 import re
 from math import ceil, log10
-from typing import List, Sequence, Tuple, Union
+from typing import Collection, List, Sequence, Tuple, Union
 
 import nibabel as nib
 import numpy as np
@@ -286,6 +286,9 @@ class DicomReader(DataReader):
 
         return vols
 
+    def __serializable_variables__(self) -> Collection[str]:
+        return self.__dict__.keys()
+
 
 class DicomWriter(DataWriter):
     """A class for writing volumes in DICOM format.
@@ -449,6 +452,9 @@ class DicomWriter(DataWriter):
         else:
             for s in tqdm(range(num_slices), disable=not self.verbose):
                 _write_dicom_file(volume_arr[..., s], headers[s], filepaths[s])
+
+    def __serializable_variables__(self) -> Collection[str]:
+        return self.__dict__.keys()
 
 
 def to_RAS_affine(headers: List[pydicom.FileDataset], default_ornt: Tuple[str, str] = None):

--- a/dosma/data_io/nifti_io.py
+++ b/dosma/data_io/nifti_io.py
@@ -6,6 +6,7 @@ This module contains NIfTI input/output helpers.
 """
 
 import os
+from typing import Collection
 
 import nibabel as nib
 import numpy as np
@@ -74,6 +75,9 @@ class NiftiReader(DataReader):
 
         return MedicalVolume(np_img, nib_img_affine)
 
+    def __serializable_variables__(self) -> Collection[str]:
+        return self.__dict__.keys()
+
 
 class NiftiWriter(DataWriter):
     """A class for writing volumes in NIfTI format.
@@ -104,3 +108,6 @@ class NiftiWriter(DataWriter):
         nib_img = nib.Nifti1Image(np_im, nib_affine)
 
         nib.save(nib_img, file_path)
+
+    def __serializable_variables__(self) -> Collection[str]:
+        return self.__dict__.keys()

--- a/dosma/models/oaiunet2d.py
+++ b/dosma/models/oaiunet2d.py
@@ -9,7 +9,6 @@ from copy import deepcopy
 import numpy as np
 
 try:
-    import keras.backend as K
     from keras.layers import BatchNormalization as BN
     from keras.layers import Concatenate, Conv2D, Conv2DTranspose, Dropout, Input, MaxPooling2D
     from keras.models import Model
@@ -167,8 +166,6 @@ class OAIUnet2D(KerasSegModel):
         # reshape mask to be (x, y, slice)
         mask = np.transpose(np.squeeze(mask, axis=-1), (1, 2, 0))
 
-        K.clear_session()
-
         vol_copy.volume = mask
 
         # reorient to match with original volume
@@ -313,8 +310,6 @@ class IWOAIOAIUnet2D(OAIUnet2D):
 
         # reshape mask to be (x, y, slice, classes)
         mask = np.transpose(mask, (1, 2, 0, 3))
-
-        K.clear_session()
 
         vols = {}
         for i, category in enumerate(["fc", "tc", "pc", "men"]):

--- a/dosma/models/seg_model.py
+++ b/dosma/models/seg_model.py
@@ -11,6 +11,11 @@ import numpy as np
 from dosma.data_io.med_volume import MedicalVolume
 from dosma.defaults import preferences
 
+try:
+    import keras.backend as K
+except ImportError:  # pragma: no-cover
+    pass
+
 
 class SegModel(ABC):
     """
@@ -98,6 +103,9 @@ class KerasSegModel(SegModel):
         :return: a Keras model
         """
         pass
+
+    def __del__(self):
+        K.clear_session()
 
 
 # ============================ Preprocessing utils ============================

--- a/tests/data_io/test_io.py
+++ b/tests/data_io/test_io.py
@@ -52,6 +52,28 @@ class TestNiftiIO(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     self.nw.save(mv, os.path.join(ututils.TEMP_PATH, "eg.dcm"))
 
+    def test_state(self):
+        nr1 = NiftiReader()
+        state_dict = nr1.state_dict()
+        state_dict = {k: "foo" for k in state_dict}
+
+        nr2 = NiftiReader()
+        nr2.load_state_dict(state_dict)
+        for k in state_dict:
+            assert getattr(nr2, k) == "foo"
+
+        nw1 = NiftiWriter()
+        state_dict = nw1.state_dict()
+        state_dict = {k: "bar" for k in state_dict}
+
+        nw2 = NiftiWriter()
+        nw2.load_state_dict(state_dict)
+        for k in state_dict:
+            assert getattr(nw2, k) == "bar"
+
+        with self.assertRaises(AttributeError):
+            nw2.load_state_dict({"foobar": "delta"})
+
 
 class TestDicomIO(unittest.TestCase):
     dr = DicomReader()
@@ -472,6 +494,28 @@ class TestDicomIO(unittest.TestCase):
 
         files = [_f for _f in os.listdir(write_path) if _f.endswith(".dcm")]
         assert len(files) == e1_expected.shape[-1]
+
+    def test_state(self):
+        dr1 = DicomReader()
+        state_dict = dr1.state_dict()
+        state_dict.update({"num_workers": 8, "group_by": None})
+
+        dr1.num_workers = 5
+        dr1.group_by = "foo"
+
+        dr2 = DicomReader()
+        state_dict = dr2.load_state_dict(state_dict)
+        assert dr2.num_workers == 8
+        assert dr2.group_by is None
+
+        dw1 = DicomWriter()
+        state_dict = dw1.state_dict()
+        state_dict.update({"num_workers": 8, "sort_by": "InstanceNumber"})
+
+        dw2 = DicomWriter()
+        state_dict = dw2.load_state_dict(state_dict)
+        assert dw2.num_workers == 8
+        assert dw2.sort_by == "InstanceNumber"
 
 
 class TestInterIO(unittest.TestCase):

--- a/tests/models/test_oaiunet2d.py
+++ b/tests/models/test_oaiunet2d.py
@@ -9,6 +9,8 @@ from dosma.models.oaiunet2d import IWOAIOAIUnet2D, IWOAIOAIUnet2DNormalized
 from dosma.models.seg_model import whiten_volume
 from dosma.tissues.femoral_cartilage import FemoralCartilage
 
+import keras.backend as K
+
 from .. import util
 
 
@@ -32,6 +34,7 @@ class TestIWOAIOAIUnet2D(unittest.TestCase):
         input_shape = (dims[0], dims[1], 1)
         model = IWOAIOAIUnet2D(input_shape=input_shape, weights_path=tissue.weights_file_path)
         masks = model.generate_mask(scan)
+        K.clear_session()
 
         for i, tissue in enumerate(classes):
             assert np.all(masks[tissue].volume == expected_seg[..., i])
@@ -124,6 +127,7 @@ class TestIWOAIOAIUnet2DNormalized(unittest.TestCase):
             input_shape=input_shape, weights_path=tissue.weights_file_path
         )
         masks = model.generate_mask(scan)
+        K.clear_session()
 
         for i, tissue in enumerate(classes):
             pred = masks[tissue].volume.astype(np.bool)

--- a/tests/scan_sequences/test_qdess.py
+++ b/tests/scan_sequences/test_qdess.py
@@ -5,6 +5,8 @@ from dosma.models.util import get_model
 from dosma.scan_sequences.qdess import QDess
 from dosma.tissues.femoral_cartilage import FemoralCartilage
 
+import keras.backend as K
+
 from .. import util
 
 SEGMENTATION_WEIGHTS_FOLDER = os.path.join(
@@ -27,6 +29,10 @@ class QDessTest(util.ScanTest):
             SEGMENTATION_MODEL, input_shape=input_shape, weights_path=tissue.weights_file_path
         )
         scan.segment(model, tissue, use_rms=True)
+
+        # This should call __del__ in KerasSegModel
+        model = None
+        K.clear_session()
 
     #
     # def test_t2_map(self):


### PR DESCRIPTION
Changes:
- Do not clear keras session after computing to allow reusing the same model
- Add state dictionaries to readers and writers for compatibility with other libraries