### PR TITLE
Add elastix support to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         run: |
           wget https://github.com/SuperElastix/elastix/releases/download/4.9.0/elastix-4.9.0-linux.tar.bz2
           ELASTIX_FOLDER="elastix"
+          mkdir -p $ELASTIX_FOLDER
           tar -xvf elastix-4.9.0-linux.tar.bz2 -C $ELASTIX_FOLDER
           ELASTIX_DIR="$(realpath $ELASTIX_FOLDER)""
           echo "PATH=${ELASTIX_DIR}/bin:${PATH}" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
+          elastix --version
           python -m pip install --upgrade pip
           make dev
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,29 +10,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  Elastix:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.6"]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Elastix
-        run: |
-          wget https://github.com/SuperElastix/elastix/releases/download/4.9.0/elastix-4.9.0-linux.tar.bz2
-          ELASTIX_FOLDER="elastix"
-          mkdir -p $ELASTIX_FOLDER
-          tar -xvf elastix-4.9.0-linux.tar.bz2 -C $ELASTIX_FOLDER
-          ELASTIX_DIR="$(realpath $ELASTIX_FOLDER)"
-          echo "PATH=${ELASTIX_DIR}/bin:${PATH}" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=${ELASTIX_DIR}/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
-      
-      - name: Print Elastix version
-        run: |
-          elastix --version
     
   Linting:
-    needs: Elastix
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -112,6 +91,16 @@ jobs:
           pip install torch
           make dev
           pip install -e '.[dev]'
+      
+      - name: Install Elastix
+        run: |
+          wget https://github.com/SuperElastix/elastix/releases/download/4.9.0/elastix-4.9.0-linux.tar.bz2
+          ELASTIX_FOLDER="elastix"
+          mkdir -p $ELASTIX_FOLDER
+          tar -xvf elastix-4.9.0-linux.tar.bz2 -C $ELASTIX_FOLDER
+          ELASTIX_DIR="$(realpath $ELASTIX_FOLDER)"
+          echo "PATH=${ELASTIX_DIR}/bin:${PATH}" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=${ELASTIX_DIR}/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
       
       - name: Test with pytest
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           ELASTIX_FOLDER="elastix"
           mkdir -p $ELASTIX_FOLDER
           tar -xvf elastix-4.9.0-linux.tar.bz2 -C $ELASTIX_FOLDER
-          ELASTIX_DIR="$(realpath $ELASTIX_FOLDER)""
+          ELASTIX_DIR="$(realpath $ELASTIX_FOLDER)"
           echo "PATH=${ELASTIX_DIR}/bin:${PATH}" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=${ELASTIX_DIR}/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 jobs:
-    
+
   Linting:
     runs-on: ubuntu-latest
     strategy:
@@ -31,7 +31,6 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          elastix --version
           python -m pip install --upgrade pip
           make dev
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,28 @@ on:
   workflow_dispatch:
 
 jobs:
+  Elastix:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.6"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Elastix
+        run: |
+          wget https://github.com/SuperElastix/elastix/releases/download/4.9.0/elastix-4.9.0-linux.tar.bz2
+          ELASTIX_FOLDER="elastix"
+          tar -xvf elastix-4.9.0-linux.tar.bz2 -C $ELASTIX_FOLDER
+          ELASTIX_DIR="$(realpath $ELASTIX_FOLDER)""
+          echo "PATH=${ELASTIX_DIR}/bin:${PATH}" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=${ELASTIX_DIR}/lib:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+      
+      - name: Print Elastix version
+        run: |
+          elastix --version
     
   Linting:
+    needs: Elastix
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/dosma/core/io/dicom_io.py
+++ b/dosma/core/io/dicom_io.py
@@ -238,7 +238,7 @@ class DicomReader(DataReader):
         temp_dicom = pydicom.read_file(lstFilesDCM[0], force=True)
         for _group in group_by:
             if _group not in temp_dicom:
-                raise ValueError("Tag {} does not exist in dicom".format(_group))
+                raise KeyError("Tag {} does not exist in dicom".format(_group))
 
         if self.num_workers:
             fn = functools.partial(pydicom.read_file, force=True)
@@ -656,9 +656,9 @@ def _update_np_dtype(arr: np.ndarray, bit_depth: int):
     dtype_dict = {
         8: [(np.int8, -128, 127), (np.uint8, 0, 255)],
         16: [
-            (np.float16, -6.55e4, 6.55e4 - 1),
-            (np.int16, -(2 ** 15), 2 ** 15),
             (np.uint16, 0, 2 ** 16 - 1),
+            (np.int16, -(2 ** 15), 2 ** 15),
+            (np.float16, -6.55e4, 6.55e4 - 1),
         ],
     }
     supported_floats = [np.float16]

--- a/dosma/core/numpy_routines.py
+++ b/dosma/core/numpy_routines.py
@@ -178,9 +178,9 @@ def clip(x, x_min, x_max, **kwargs):
         The ``out`` positional argument is not currently supported.
     """
     if isinstance(x_min, MedicalVolume):
-        x_min = x_min.A
+        x_min = x_min.reformat_as(x).A
     if isinstance(x_max, MedicalVolume):
-        x_max = x_max.A
+        x_max = x_max.reformat_as(x).A
 
     arr = np.clip(x.A, x_min, x_max, **kwargs)
     return x._partial_clone(volume=arr)

--- a/dosma/core/registration.py
+++ b/dosma/core/registration.py
@@ -5,6 +5,7 @@ import platform
 import shutil
 import subprocess
 import uuid
+import sys
 import warnings
 from functools import partial
 from typing import Dict, Sequence, Union
@@ -92,7 +93,7 @@ def register(
     assert issubclass(rtype, (Dict, Sequence))  # `rtype` must be dict or tuple
     has_output_path = bool(output_path)
     if not output_path:
-        output_path = os.path.join(env.temp_dir(), f"register-{str(uuid.uuid1())}")
+        output_path = os.path.join(env.temp_dir(), f"register-{str(uuid.uuid1())}-{str(uuid.uuid4())}")
 
     moving = [moving] if isinstance(moving, (MedicalVolume, str)) else moving
     moving_masks = (
@@ -241,7 +242,13 @@ def apply_warp(
     if rtype == str and not has_output_path:
         raise ValueError("`output_path` must be specified when `rtype=str`")
     if not output_path:
-        output_path = os.path.join(env.temp_dir(), f"apply_warp-{str(uuid.uuid1())}")
+        # TODO: Add path generation that prevents collisions during multiprocessing.
+        # When multiprocessing executes rapidly and poor seed is set, the uuids have
+        # collided. To avoid this, we append the process name to the directory that is
+        # created.
+        output_path = os.path.join(env.temp_dir(), f"apply_warp-{str(uuid.uuid1())}-{str(uuid.uuid4())}")
+        if not _is_main_process():
+            output_path += mp.current_process().name
     output_path = os.path.abspath(output_path)
     os.makedirs(output_path, exist_ok=True)
 
@@ -457,3 +464,8 @@ def _local_lib_dir():
     files = [x for x in os.listdir(fc._DOSMA_ELASTIX_FOLDER) if x.startswith("libANNlib")]
     if len(files) > 0:
         return fc._DOSMA_ELASTIX_FOLDER
+
+
+def _is_main_process():
+    py_version = tuple(sys.version_info[0:2])
+    return ((py_version < (3, 8) and mp.current_process().name == "MainProcess") or (py_version >= (3, 8) and mp.parent_process() is None))

--- a/dosma/core/registration.py
+++ b/dosma/core/registration.py
@@ -276,7 +276,7 @@ def apply_warp(
 
     if os.path.isfile(mv_filepath):
         os.remove(mv_filepath)
-    if not has_output_path:
+    if not has_output_path and os.path.isdir(output_path):
         shutil.rmtree(output_path)
 
     return out

--- a/dosma/core/registration.py
+++ b/dosma/core/registration.py
@@ -92,7 +92,7 @@ def register(
     assert issubclass(rtype, (Dict, Sequence))  # `rtype` must be dict or tuple
     has_output_path = bool(output_path)
     if not output_path:
-        output_path = os.path.join(env.temp_dir(), "register")
+        output_path = os.path.join(env.temp_dir(), f"register-{str(uuid.uuid1())}")
 
     moving = [moving] if isinstance(moving, (MedicalVolume, str)) else moving
     moving_masks = (

--- a/dosma/core/registration.py
+++ b/dosma/core/registration.py
@@ -4,8 +4,8 @@ import os
 import platform
 import shutil
 import subprocess
-import uuid
 import sys
+import uuid
 import warnings
 from functools import partial
 from typing import Dict, Sequence, Union
@@ -93,7 +93,9 @@ def register(
     assert issubclass(rtype, (Dict, Sequence))  # `rtype` must be dict or tuple
     has_output_path = bool(output_path)
     if not output_path:
-        output_path = os.path.join(env.temp_dir(), f"register-{str(uuid.uuid1())}-{str(uuid.uuid4())}")
+        output_path = os.path.join(
+            env.temp_dir(), f"register-{str(uuid.uuid1())}-{str(uuid.uuid4())}"
+        )
 
     moving = [moving] if isinstance(moving, (MedicalVolume, str)) else moving
     moving_masks = (
@@ -246,7 +248,9 @@ def apply_warp(
         # When multiprocessing executes rapidly and poor seed is set, the uuids have
         # collided. To avoid this, we append the process name to the directory that is
         # created.
-        output_path = os.path.join(env.temp_dir(), f"apply_warp-{str(uuid.uuid1())}-{str(uuid.uuid4())}")
+        output_path = os.path.join(
+            env.temp_dir(), f"apply_warp-{str(uuid.uuid1())}-{str(uuid.uuid4())}"
+        )
         if not _is_main_process():
             output_path += mp.current_process().name
     output_path = os.path.abspath(output_path)
@@ -468,4 +472,6 @@ def _local_lib_dir():
 
 def _is_main_process():
     py_version = tuple(sys.version_info[0:2])
-    return ((py_version < (3, 8) and mp.current_process().name == "MainProcess") or (py_version >= (3, 8) and mp.parent_process() is None))
+    return (py_version < (3, 8) and mp.current_process().name == "MainProcess") or (
+        py_version >= (3, 8) and mp.parent_process() is None
+    )

--- a/dosma/models/seg_model.py
+++ b/dosma/models/seg_model.py
@@ -13,7 +13,7 @@ from dosma.defaults import preferences
 
 try:
     import keras.backend as K
-except ImportError:  # pragma: no-cover
+except ImportError:  # pragma: no cover
     pass
 
 

--- a/dosma/scan_sequences/scan_io.py
+++ b/dosma/scan_sequences/scan_io.py
@@ -1,10 +1,9 @@
 import inspect
-import logging
 import os
 import warnings
 from abc import ABC
 from pathlib import Path
-from typing import Any, Dict, Sequence, Set, Union
+from typing import Any, Dict, Optional, Sequence, Set, Union
 
 import pydicom
 
@@ -32,7 +31,7 @@ class ScanIOMixin(ABC):
     # This is just a summary on variables used in this abstract class,
     # the proper values/initialization should be done in child class.
     NAME: str
-    __DEFAULT_SPLIT_BY__: str
+    __DEFAULT_SPLIT_BY__: Optional[str]
     _from_file_args: Dict[str, Any]
 
     @classmethod
@@ -114,7 +113,7 @@ class ScanIOMixin(ABC):
 
         for k, v in data.items():
             if not hasattr(scan, k) and not force:
-                logging.warn(f"{cls.__name__} does not have attribute {k}. Skipping...")
+                warnings.warn(f"{cls.__name__} does not have attribute {k}. Skipping...")
                 continue
             scan.__setattr__(k, v)
 
@@ -419,7 +418,7 @@ class ScanIOMixin(ABC):
         return data
 
     def __serializable_variables__(
-        self, ignore_types=(pydicom.FileDataset, Tissue), ignore_attrs=()
+        self, ignore_types=(pydicom.FileDataset, pydicom.Dataset, Tissue), ignore_attrs=()
     ) -> Set:
         """
         By default, all instance attributes are serialized except those
@@ -442,8 +441,6 @@ class ScanIOMixin(ABC):
             if attr.upper() == attr or (attr.startswith("__") and attr.endswith("__")):
                 continue
             if callable(value) or isinstance(value, property):
-                continue
-            if _contains_type(value, ignore_types):
                 continue
             serializable.append(attr)
 

--- a/dosma/scan_sequences/scan_io.py
+++ b/dosma/scan_sequences/scan_io.py
@@ -64,7 +64,7 @@ class ScanIOMixin(ABC):
             group_by = cls.__DEFAULT_SPLIT_BY__
         volumes = dr.load(dir_or_files, group_by, ignore_ext)
 
-        if isinstance(dir_or_files, str):
+        if isinstance(dir_or_files, (str, Path, os.PathLike)):
             dir_or_files = os.path.abspath(dir_or_files)
         else:
             dir_or_files = type(dir_or_files)([os.path.abspath(x) for x in dir_or_files])

--- a/dosma/utils/io_utils.py
+++ b/dosma/utils/io_utils.py
@@ -127,7 +127,7 @@ def save_tables(
     writer.save()
 
 
-def init_logger(log_file: str, debug: bool = False):
+def init_logger(log_file: str, debug: bool = False):  # pragma: no cover
     """Initialize logger.
 
     Args:

--- a/tests/core/io/test_dicom_io.py
+++ b/tests/core/io/test_dicom_io.py
@@ -493,7 +493,7 @@ class TestDicomIO(ututils.TempPathMixin):
         # sort by
         mv2 = dr.load(filepath, sort_by="InstanceNumber")[0]
         assert mv2.is_identical(mv)
-    
+
     def test_save_different_bits(self):
         """Test writing volume where bit depth has changed."""
         filepath = get_testdata_file("MR_small.dcm")
@@ -510,7 +510,7 @@ class TestDicomIO(ututils.TempPathMixin):
         dr = DicomReader(group_by=None)
         mv2 = dr.load(out_dir)[0]
         assert mv2.is_identical(mv)
-    
+
     def test_save(self):
         filepath = get_testdata_file("MR_small.dcm")
         dr = DicomReader(group_by=None)
@@ -523,7 +523,7 @@ class TestDicomIO(ututils.TempPathMixin):
         assert mv2.is_identical(mv_base)
 
         out_dir = os.path.join(self.data_dirpath, "test_save_no_headers")
-        mv = MedicalVolume(np.ones((10,10,10)), np.eye(4))
+        mv = MedicalVolume(np.ones((10, 10, 10)), np.eye(4))
         dw = DicomWriter()
         with self.assertRaises(ValueError):
             dw.save(mv, out_dir)
@@ -555,32 +555,48 @@ class TestDicomIO(ututils.TempPathMixin):
         out_dir = self.data_dirpath / "test_get_files"
         os.makedirs(out_dir, exist_ok=True)
         filenames = [
-            "I0001.dcm", "I0002.dcm", "I0003.dcm", "I0004.dcm", "I0005.dcm",
-            "I0006", "I0007", "I0008", "I0009", "I0010",
-            "I0011-sft.dcm", "I0012-sft.dcm", "I0013-sft.dcm", "I0014-sft.dcm", "I0015-sft.dcm",
-            ".I0016.dcm"
+            "I0001.dcm",
+            "I0002.dcm",
+            "I0003.dcm",
+            "I0004.dcm",
+            "I0005.dcm",
+            "I0006",
+            "I0007",
+            "I0008",
+            "I0009",
+            "I0010",
+            "I0011-sft.dcm",
+            "I0012-sft.dcm",
+            "I0013-sft.dcm",
+            "I0014-sft.dcm",
+            "I0015-sft.dcm",
+            ".I0016.dcm",
         ]
         filenames = [out_dir / fname for fname in filenames]
         filenames_str = [str(x) for x in filenames]
         for fname in filenames:
             with open(fname, "w"):
                 pass
-    
+
         dr = DicomReader()
         files = dr.get_files(out_dir, ignore_ext=False, ignore_hidden=False)
-        assert set(files) == set(x for x in filenames_str if x.endswith(".dcm"))
+        assert set(files) == {x for x in filenames_str if x.endswith(".dcm")}
 
         dr = DicomReader()
         files = dr.get_files(out_dir, ignore_ext=False, ignore_hidden=True)
-        assert set(files) == set(x for x in filenames_str if not os.path.basename(x).startswith(".") and x.endswith(".dcm"))
+        assert set(files) == {
+            x
+            for x in filenames_str
+            if not os.path.basename(x).startswith(".") and x.endswith(".dcm")
+        }
 
         dr = DicomReader()
         files = dr.get_files(out_dir, ignore_ext=True, ignore_hidden=False)
-        assert set(files) == set(x for x in filenames_str)
+        assert set(files) == set(filenames_str)
 
         dr = DicomReader()
         files = dr.get_files(out_dir, ignore_ext=True, ignore_hidden=True)
-        assert set(files) == set(x for x in filenames_str if not os.path.basename(x).startswith("."))
+        assert set(files) == {x for x in filenames_str if not os.path.basename(x).startswith(".")}
 
         with self.assertRaises(NotADirectoryError):
             dr.get_files(out_dir / "some-folder")

--- a/tests/core/io/test_dicom_io.py
+++ b/tests/core/io/test_dicom_io.py
@@ -15,7 +15,7 @@ from dosma.core.med_volume import MedicalVolume
 from ... import util as ututils
 
 
-class TestDicomIO(unittest.TestCase):
+class TestDicomIO(ututils.TempPathMixin):
     dr = DicomReader()
     dw = DicomWriter()
 
@@ -470,6 +470,64 @@ class TestDicomIO(unittest.TestCase):
         assert np.all(mv_pydicom_loaded.pixel_array == arr)
         assert self.are_equivalent_headers(mv_pydicom_loaded, mv_pydicom)
 
+    def test_load_pydicom_data(self):
+        filepath = get_testdata_file("MR_small.dcm")
+        dr = DicomReader(group_by=None)
+        mv = dr.load(filepath)[0]
+
+        # CT does not have EchoNumbers field in header.
+        with self.assertRaises(KeyError):
+            dr.load(get_testdata_file("CT_small.dcm"), group_by="EchoNumbers")
+        with self.assertRaises(KeyError):
+            dr.load(get_testdata_file("CT_small.dcm"), sort_by="EchoNumbers")
+
+        # Multiprocessing
+        dr_mp = DicomReader(group_by=None, num_workers=1)
+        mv2 = dr_mp.load(filepath)[0]
+        assert mv2.is_identical(mv)
+
+        dr_mp = DicomReader(group_by=None, num_workers=1, verbose=True)
+        mv2 = dr_mp.load(filepath)[0]
+        assert mv2.is_identical(mv)
+
+        # sort by
+        mv2 = dr.load(filepath, sort_by="InstanceNumber")[0]
+        assert mv2.is_identical(mv)
+    
+    def test_save_different_bits(self):
+        """Test writing volume where bit depth has changed."""
+        filepath = get_testdata_file("MR_small.dcm")
+        dr = DicomReader(group_by=None)
+        mv_base = dr.load(filepath)[0]
+
+        arr = (np.random.rand(*mv_base.shape) > 0.5).astype(np.uint8) * 255
+        mv = mv_base._partial_clone(volume=arr)
+
+        dw = DicomWriter()
+        out_dir = os.path.join(self.data_dirpath, "test_write_different_bits")
+        dw.save(mv, dir_path=out_dir)
+
+        dr = DicomReader(group_by=None)
+        mv2 = dr.load(out_dir)[0]
+        assert mv2.is_identical(mv)
+    
+    def test_save(self):
+        filepath = get_testdata_file("MR_small.dcm")
+        dr = DicomReader(group_by=None)
+        mv_base = dr.load(filepath)[0]
+
+        out_dir = os.path.join(self.data_dirpath, "test_save_sort_by")
+        dw = DicomWriter()
+        dw.save(mv_base, out_dir, sort_by="InstanceNumber")
+        mv2 = dr.load(filepath)[0]
+        assert mv2.is_identical(mv_base)
+
+        out_dir = os.path.join(self.data_dirpath, "test_save_no_headers")
+        mv = MedicalVolume(np.ones((10,10,10)), np.eye(4))
+        dw = DicomWriter()
+        with self.assertRaises(ValueError):
+            dw.save(mv, out_dir)
+
     def test_state(self):
         dr1 = DicomReader()
         state_dict = dr1.state_dict()
@@ -491,6 +549,41 @@ class TestDicomIO(unittest.TestCase):
         state_dict = dw2.load_state_dict(state_dict)
         assert dw2.num_workers == 8
         assert dw2.sort_by == "InstanceNumber"
+
+    def test_get_files(self):
+        # Make dummy files with some properties.
+        out_dir = self.data_dirpath / "test_get_files"
+        os.makedirs(out_dir, exist_ok=True)
+        filenames = [
+            "I0001.dcm", "I0002.dcm", "I0003.dcm", "I0004.dcm", "I0005.dcm",
+            "I0006", "I0007", "I0008", "I0009", "I0010",
+            "I0011-sft.dcm", "I0012-sft.dcm", "I0013-sft.dcm", "I0014-sft.dcm", "I0015-sft.dcm",
+            ".I0016.dcm"
+        ]
+        filenames = [out_dir / fname for fname in filenames]
+        filenames_str = [str(x) for x in filenames]
+        for fname in filenames:
+            with open(fname, "w"):
+                pass
+    
+        dr = DicomReader()
+        files = dr.get_files(out_dir, ignore_ext=False, ignore_hidden=False)
+        assert set(files) == set(x for x in filenames_str if x.endswith(".dcm"))
+
+        dr = DicomReader()
+        files = dr.get_files(out_dir, ignore_ext=False, ignore_hidden=True)
+        assert set(files) == set(x for x in filenames_str if not os.path.basename(x).startswith(".") and x.endswith(".dcm"))
+
+        dr = DicomReader()
+        files = dr.get_files(out_dir, ignore_ext=True, ignore_hidden=False)
+        assert set(files) == set(x for x in filenames_str)
+
+        dr = DicomReader()
+        files = dr.get_files(out_dir, ignore_ext=True, ignore_hidden=True)
+        assert set(files) == set(x for x in filenames_str if not os.path.basename(x).startswith("."))
+
+        with self.assertRaises(NotADirectoryError):
+            dr.get_files(out_dir / "some-folder")
 
 
 if __name__ == "__main__":

--- a/tests/core/test_registration.py
+++ b/tests/core/test_registration.py
@@ -69,7 +69,7 @@ class TestApplyWarp(util.TempPathMixin):
         """Verify that multiprocessing compatible with apply_warp."""
         # Generate viable transform file.
         mvs = _generate_translated_vols(n=4)
-        out_path = os.path.join(self.data_dirpath, "test-register")
+        out_path = os.path.join(self.data_dirpath, "test-apply-warp")
         out, _ = register(
             mvs[0],
             mvs[1],

--- a/tests/core/test_registration.py
+++ b/tests/core/test_registration.py
@@ -10,7 +10,6 @@ import dosma.file_constants as fc
 from dosma.core.med_volume import MedicalVolume
 from dosma.core.orientation import to_affine
 from dosma.core.registration import apply_warp, register
-from dosma.utils import env
 
 from .. import util
 
@@ -26,12 +25,11 @@ def _generate_translated_vols(n=3):
     return mvs
 
 
-class TestRegister(unittest.TestCase):
-    unittest.skipIf(not util.is_elastix_available(), "elastix is not available")
-
+class TestRegister(util.TempPathMixin):
+    @unittest.skipIf(not util.is_elastix_available(), "elastix is not available")
     def test_multiprocessing(self):
         mvs = _generate_translated_vols()
-        data_dir = os.path.join(env.temp_dir(), "test-register-mp")
+        data_dir = os.path.join(self.data_dirpath, "test-register-mp")
 
         out_path = os.path.join(data_dir, "expected")
         _, expected = register(
@@ -65,14 +63,13 @@ class TestRegister(unittest.TestCase):
         shutil.rmtree(data_dir)
 
 
-class TestApplyWarp(unittest.TestCase):
-    unittest.skipIf(not util.is_elastix_available(), "elastix is not available")
-
+class TestApplyWarp(util.TempPathMixin):
+    @unittest.skipIf(not util.is_elastix_available(), "elastix is not available")
     def test_multiprocessing(self):
         """Verify that multiprocessing compatible with apply_warp."""
         # Generate viable transform file.
         mvs = _generate_translated_vols(n=4)
-        out_path = os.path.join(env.temp_dir(), "test-register")
+        out_path = os.path.join(self.data_dirpath, "test-register")
         out, _ = register(
             mvs[0],
             mvs[1],

--- a/tests/core/test_registration.py
+++ b/tests/core/test_registration.py
@@ -62,6 +62,29 @@ class TestRegister(util.TempPathMixin):
 
         shutil.rmtree(data_dir)
 
+    def test_complex(self):
+        mvs = _generate_translated_vols()
+        mask = mvs[0]._partial_clone(volume=np.ones(mvs[0].shape))
+        data_dir = os.path.join(self.data_dirpath, "test-register-complex-sequential-moving-masks")
+
+        out_path = os.path.join(data_dir, "expected")
+        _ = register(
+            mvs[0],
+            mvs[1:],
+            [fc.ELASTIX_AFFINE_PARAMS_FILE, fc.ELASTIX_AFFINE_PARAMS_FILE],
+            out_path,
+            target_mask=mask,
+            use_mask=[True, True],
+            sequential=True,
+            num_workers=0,
+            num_threads=2,
+            return_volumes=True,
+            rtype=tuple,
+            show_pbar=True,
+        )
+
+        shutil.rmtree(data_dir)
+
 
 class TestApplyWarp(util.TempPathMixin):
     @unittest.skipIf(not util.is_elastix_available(), "elastix is not available")

--- a/tests/scan_sequences/test_scan_io.py
+++ b/tests/scan_sequences/test_scan_io.py
@@ -1,6 +1,4 @@
 import os
-import shutil
-import unittest
 
 import numpy as np
 import pydicom

--- a/tests/scan_sequences/test_scan_io.py
+++ b/tests/scan_sequences/test_scan_io.py
@@ -1,0 +1,144 @@
+import os
+import shutil
+import unittest
+
+import numpy as np
+import pydicom
+from pydicom.data import get_testdata_file
+
+from dosma.scan_sequences.scan_io import ScanIOMixin
+
+from .. import util as ututils
+
+
+class MockScanIOMixin(ScanIOMixin):
+    """Mock class for the :cls:`ScanIOMixin`.
+
+    This mixin will be used to load an MR slice hosted on pydicom: ``MR_small.dcm``.
+    """
+
+    NAME = "mock-scan-io"
+    __DEFAULT_SPLIT_BY__ = None
+
+    def __init__(self, volumes, foo="foo", bar="bar") -> None:
+        self.volumes = volumes
+        self._from_file_args = {}
+
+        self.foo = foo
+        self._bar = bar
+
+        # Attributes that should not be serialized
+        self._temp_path = "some/path"
+        self.__some_attr__ = 1234
+        self.__pydicom_header__ = pydicom.Dataset()
+
+    @property
+    def some_property(self):
+        return "new/path"
+
+
+class TestScanIOMixin(ututils.TempPathMixin):
+    def test_from_dicom(self):
+        mr_dcm = get_testdata_file("MR_small.dcm")
+        fs = pydicom.read_file(mr_dcm)
+        arr = fs.pixel_array
+
+        scan = MockScanIOMixin.from_dicom(mr_dcm, foo="foofoo", bar="barbar")
+        assert len(scan.volumes) == 1
+        assert np.all(scan.volumes[0] == arr[..., np.newaxis])
+        assert scan.foo == "foofoo"
+        assert scan._bar == "barbar"
+        assert scan._from_file_args == {
+            "dir_or_files": mr_dcm,
+            "ignore_ext": False,
+            "group_by": None,
+            "_type": "dicom",
+        }
+
+        scan = MockScanIOMixin.from_dicom([mr_dcm], foo="foofoo", bar="barbar")
+        assert len(scan.volumes) == 1
+        assert np.all(scan.volumes[0] == arr[..., np.newaxis])
+        assert scan.foo == "foofoo"
+        assert scan._bar == "barbar"
+        assert scan._from_file_args == {
+            "dir_or_files": [mr_dcm],
+            "ignore_ext": False,
+            "group_by": None,
+            "_type": "dicom",
+        }
+
+    def test_from_dict(self):
+        mr_dcm = get_testdata_file("MR_small.dcm")
+        scan1 = MockScanIOMixin.from_dicom(mr_dcm)
+
+        scan2 = MockScanIOMixin.from_dict(scan1.__dict__)
+        assert scan1.__dict__.keys() == scan2.__dict__.keys()
+        for k in scan1.__dict__.keys():
+            assert scan1.__dict__[k] == scan2.__dict__[k]
+
+        new_dict = dict(scan1.__dict__)
+        new_dict["extra_bool_field"] = True
+        with self.assertWarns(UserWarning):
+            scan2 = MockScanIOMixin.from_dict(new_dict)
+        assert not hasattr(scan2, "extra_bool_field")
+
+        scan2 = MockScanIOMixin.from_dict(new_dict, force=True)
+        assert hasattr(scan2, "extra_bool_field")
+
+    def test_save_load(self):
+        mr_dcm = get_testdata_file("MR_small.dcm")
+        scan = MockScanIOMixin.from_dicom(mr_dcm)
+        scan.foo = "foofoo"
+        scan._bar = "barbar"
+
+        vars = scan.__serializable_variables__()
+        serializable = ("foo", "_bar", "volumes", "_from_file_args")
+        not_serializable = ("_temp_path", "__some_attr__", "__pydicom_header__", "some_property")
+        assert all(x in vars for x in serializable)
+        assert all(x not in vars for x in not_serializable)
+
+        save_dir = os.path.join(self.data_dirpath, "test_save_load")
+        save_path = scan.save(save_dir, save_custom=True)
+        assert os.path.isfile(save_path)
+
+        scan_loaded = MockScanIOMixin.load(save_path)
+        assert scan_loaded.volumes[0].is_identical(scan.volumes[0])
+        assert scan_loaded.foo == "foofoo"
+        assert scan._bar == "barbar"
+
+        scan_loaded = MockScanIOMixin.load(save_dir)
+        assert scan_loaded.volumes[0].is_identical(scan.volumes[0])
+        assert scan_loaded.foo == "foofoo"
+        assert scan._bar == "barbar"
+
+        with self.assertRaises(FileNotFoundError):
+            _ = MockScanIOMixin.load(os.path.join(save_dir, "some-path.pik"))
+
+        new_dict = dict(scan.__dict__)
+        new_dict.pop("volumes")
+        with self.assertWarns(UserWarning):
+            scan_loaded = MockScanIOMixin.load(new_dict)
+        assert scan_loaded.volumes[0].is_identical(scan.volumes[0])
+        assert scan_loaded.foo == "foofoo"
+        assert scan._bar == "barbar"
+
+        # Backwards compatibility with how DOSMA wrote files versions<0.0.12
+        new_dict = dict(scan.__dict__)
+        new_dict.pop("volumes")
+        new_dict.pop("_from_file_args")
+        new_dict.update({"dicom_path": mr_dcm, "ignore_ext": False, "series_number": 7})
+        with self.assertWarns(UserWarning):
+            scan_loaded = MockScanIOMixin.load(new_dict)
+        assert scan_loaded.volumes[0].is_identical(scan.volumes[0])
+        assert scan_loaded.foo == "foofoo"
+        assert scan._bar == "barbar"
+
+        new_dict = dict(scan.__dict__)
+        new_dict.pop("volumes")
+        new_dict.pop("_from_file_args")
+        with self.assertRaises(ValueError):
+            _ = MockScanIOMixin.load(new_dict)
+
+        save_dir = os.path.join(self.data_dirpath, "test_save_data")
+        with self.assertWarns(DeprecationWarning):
+            scan.save_data(save_dir)

--- a/tests/util.py
+++ b/tests/util.py
@@ -27,7 +27,7 @@ UNITTEST_DATA_PATH = os.environ.get(
 )
 UNITTEST_SCANDATA_PATH = os.path.join(UNITTEST_DATA_PATH, "scans")
 TEMP_PATH = os.path.join(
-    UNITTEST_SCANDATA_PATH, f"temp-{str(uuid.uuid1())}"
+    UNITTEST_SCANDATA_PATH, f"temp-{str(uuid.uuid1())}-{str(uuid.uuid4())}"
 )  # should be used when for writing with assert_raises clauses
 
 SCANS = ["qdess", "mapss", "cubequant", "cones"]

--- a/tests/util.py
+++ b/tests/util.py
@@ -4,11 +4,11 @@ import datetime
 import os
 import re
 import shutil
-from pathlib import Path
 import subprocess
 import tempfile
 import unittest
 import uuid
+from pathlib import Path
 from typing import Callable
 
 import natsort
@@ -19,7 +19,7 @@ from dosma.cli import SUPPORTED_SCAN_TYPES, parse_args
 from dosma.core.fitting import monoexponential
 from dosma.core.io.format_io import ImageDataFormat
 from dosma.core.med_volume import MedicalVolume
-from dosma.utils import env, io_utils
+from dosma.utils import env
 from dosma.utils.cmd_line_utils import ActionWrapper
 
 UNITTEST_DATA_PATH = os.environ.get(
@@ -201,9 +201,11 @@ class TempPathMixin(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.data_dirpath = Path(os.path.join(
-            get_data_path(os.path.join(UNITTEST_SCANDATA_PATH, "temp")), f"{cls.__name__}"
-        ))
+        cls.data_dirpath = Path(
+            os.path.join(
+                get_data_path(os.path.join(UNITTEST_SCANDATA_PATH, "temp")), f"{cls.__name__}"
+            )
+        )
         os.makedirs(cls.data_dirpath, exist_ok=True)
 
     @classmethod
@@ -225,9 +227,9 @@ class ScanTest(TempPathMixin):
     def setUpClass(cls):
         super().setUpClass()
         if is_data_available():
-            cls.dicom_dirpath = Path(get_dicoms_path(
-                os.path.join(UNITTEST_SCANDATA_PATH, cls.SCAN_TYPE.NAME)
-            ))
+            cls.dicom_dirpath = Path(
+                get_dicoms_path(os.path.join(UNITTEST_SCANDATA_PATH, cls.SCAN_TYPE.NAME))
+            )
 
     def test_has_cmd_line_actions_attr(self):
         """

--- a/tests/util.py
+++ b/tests/util.py
@@ -27,7 +27,7 @@ UNITTEST_DATA_PATH = os.environ.get(
 )
 UNITTEST_SCANDATA_PATH = os.path.join(UNITTEST_DATA_PATH, "scans")
 TEMP_PATH = os.path.join(
-    UNITTEST_SCANDATA_PATH, "temp"
+    UNITTEST_SCANDATA_PATH, f"temp-{str(uuid.uuid1())}"
 )  # should be used when for writing with assert_raises clauses
 
 SCANS = ["qdess", "mapss", "cubequant", "cones"]

--- a/tests/utils/test_io_utils.py
+++ b/tests/utils/test_io_utils.py
@@ -45,9 +45,9 @@ class UtilsTest(unittest.TestCase):
             assert (datas[data] == datas2[data]).all()
 
     def test_save_tables(self):
-        df = pd.DataFrame({"a": [1,2,3,4], "b": [5,6,7,8]})
+        df = pd.DataFrame({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
         path = os.path.join(IO_UTILS_DATA, "table.xlsx")
         io_utils.save_tables(path, [df])
 
-        df2 = pd.read_excel(path, engine='openpyxl')
+        df2 = pd.read_excel(path, engine="openpyxl")
         assert np.all(df == df2)

--- a/tests/utils/test_io_utils.py
+++ b/tests/utils/test_io_utils.py
@@ -3,6 +3,7 @@ import shutil
 import unittest
 
 import numpy as np
+import pandas as pd
 
 from dosma.utils import io_utils
 
@@ -42,3 +43,11 @@ class UtilsTest(unittest.TestCase):
 
         for data in datas:
             assert (datas[data] == datas2[data]).all()
+
+    def test_save_tables(self):
+        df = pd.DataFrame({"a": [1,2,3,4], "b": [5,6,7,8]})
+        path = os.path.join(IO_UTILS_DATA, "table.xlsx")
+        io_utils.save_tables(path, [df])
+
+        df2 = pd.read_excel(path, engine='openpyxl')
+        assert np.all(df == df2)


### PR DESCRIPTION
Add default elastix 4.9.0 installation during CI testing. this will let us validate the registration module with higher efficacy.

Other changes are based on the fact that we added elastix support to CI