### PR TITLE
v0.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ test-cov:
 	set -e
 	pytest tests/ --cov=./ --cov-report=xml
 
+test-like-ga:
+	set -e
+	DOSMA_UNITTEST_DISABLE_DATA=true pytest tests/
+
 build-docs:
 	set -e
 	mkdir -p docs/source/_static

--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ DOSMA provides efficient readers for DICOM and NIfTI formats built on nibabel an
 parallel with multiple workers and structured into the appropriate 3D volume(s). For example, multi-echo and dynamic contrast-enhanced (DCE) MRI scans have multiple volumes acquired at different echo times and trigger times, respectively. These can be loaded into multiple volumes with ease:
 
 ```python
-dr = dosma.DicomReader(verbose=True, num_workers=8)
-multi_echo_scan = dr.load("/path/to/multi-echo/scan", group_by="EchoNumbers")
-dce_scan = dr.load("/path/to/dce/scan", group_by="TriggerTime")
+import dosma as dm
+
+multi_echo_scan = dm.load("/path/to/multi-echo/scan", group_by="EchoNumbers", num_workers=8, verbose=True)
+dce_scan = dm.load("/path/to/dce/scan", group_by="TriggerTime")
 ```
 
 ### Data-Embedded Medical Images
@@ -94,7 +95,7 @@ masks = model.generate_mask(mv)
 ```
 
 ### Parallelizable Operations
-DOSMA supports parallelization for curve fitting and image registration operations.
+DOSMA supports parallelization for compute-heavy operations, like curve fitting and image registration.
 Image registration is supported thru the [elastix/transformix](https://elastix.lumc.nl/download.php) libraries. For example we can use multiple workers to register volumes to a target, and use the registered outputs for per-voxel monoexponential fitting:
 
 ```python

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,7 +5,7 @@ nested-lookup
 nibabel
 nipype
 pandas
-pydicom>=1.6.0,<=2.0.0
+pydicom>=1.6.0
 scikit-image
 scipy
 seaborn

--- a/docs/source/core_api.rst
+++ b/docs/source/core_api.rst
@@ -89,6 +89,8 @@ Image I/O
    :toctree: generated
    :nosignatures:
 
+   dosma.read
+   dosma.write
    dosma.NiftiReader
    dosma.NiftiWriter
    dosma.DicomReader

--- a/docs/source/guide_basic.rst
+++ b/docs/source/guide_basic.rst
@@ -47,14 +47,19 @@ and set metadata:
 Similarly, to load a NIfTI volume, we use the :class:`NiftiReader` class:
 
 >>> nr = dm.NiftiReader()
->>> volume = nr.load("/path/to/nifti/file")
+>>> volume = nr.load("/path/to/nifti/file.nii.gz")
 
-With NIfTI volumes stored in ``.nii`` (not ``.nii.gz``) files, we can also load
-the volume in memmap mode. This makes loading much faster and allows easy interaction
+NIfTI volumes can also be loaded in memmap mode. This makes loading much faster and allows easy interaction
 with larger-than-memory arrays. Only when the volume is modified will the volume
 be loaded into memory and modified.
 
->>> volume = nr.load("/path/to/nifti/file", memmap=True)
+>>> volume = nr.load("/path/to/nifti/file", mmap=True)
+
+Images in all supported data formats can also be loaded and written using ``dosma.read`` and ``dosma.write``:
+
+>>> import dosma as dm
+>>> dm.load("/path/to/dicom/folder", group_by="EchoNumbers")
+>>> dm.load("/path/to/nifti/file.nii.gz", mmap=True)
 
 
 Reformatting Images

--- a/docs/source/guide_basic.rst
+++ b/docs/source/guide_basic.rst
@@ -49,6 +49,13 @@ Similarly, to load a NIfTI volume, we use the :class:`NiftiReader` class:
 >>> nr = dm.NiftiReader()
 >>> volume = nr.load("/path/to/nifti/file")
 
+With NIfTI volumes stored in ``.nii`` (not ``.nii.gz``) files, we can also load
+the volume in memmap mode. This makes loading much faster and allows easy interaction
+with larger-than-memory arrays. Only when the volume is modified will the volume
+be loaded into memory and modified.
+
+>>> volume = nr.load("/path/to/nifti/file", memmap=True)
+
 
 Reformatting Images
 =========================

--- a/dosma/__init__.py
+++ b/dosma/__init__.py
@@ -2,8 +2,6 @@
 """
 from dosma.utils.logger import setup_logger  # noqa
 
-setup_logger()
-
 from dosma import core as _core  # noqa: E402
 
 from dosma.core import *  # noqa
@@ -11,8 +9,34 @@ from dosma.defaults import preferences  # noqa
 from dosma.utils.collect_env import collect_env_info  # noqa
 from dosma.utils.env import debug  # noqa
 
+from dosma.core.med_volume import MedicalVolume  # noqa: F401
+from dosma.core.io.format_io_utils import read, write  # noqa: F401
+from dosma.core.io.format_io import ImageDataFormat  # noqa: F401
+from dosma.core.io.dicom_io import DicomReader, DicomWriter  # noqa: F401
+from dosma.core.io.nifti_io import NiftiReader, NiftiWriter  # noqa: F401
+from dosma.core.device import Device, get_device, to_device  # noqa: F401
+from dosma.core.orientation import to_affine  # noqa: F401
+from dosma.core.registration import (  # noqa: F401
+    register,
+    apply_warp,
+    symlink_elastix,
+    unlink_elastix,
+)
+from dosma.core.fitting import (  # noqa: F401
+    CurveFitter,
+    PolyFitter,
+    MonoExponentialFit,
+    curve_fit,
+    polyfit,
+)
+
+import dosma.core.numpy_routines as numpy_routines  # noqa: F401
+
+
 __all__ = []
 __all__.extend(_core.__all__)
+
+setup_logger()
 
 # This line will be programatically read/write by setup.py.
 # Leave them at the bottom of this file and don't touch them.

--- a/dosma/core/io/dicom_io.py
+++ b/dosma/core/io/dicom_io.py
@@ -318,6 +318,8 @@ class DicomReader(DataReader):
     def __serializable_variables__(self) -> Collection[str]:
         return self.__dict__.keys()
 
+    read = load  # pragma: no cover
+
 
 class DicomWriter(DataWriter):
     """A class for writing volumes in DICOM format.
@@ -486,6 +488,8 @@ class DicomWriter(DataWriter):
 
     def __serializable_variables__(self) -> Collection[str]:
         return self.__dict__.keys()
+
+    write = save  # pragma: no cover
 
 
 def to_RAS_affine(headers: List[pydicom.FileDataset], default_ornt: Tuple[str, str] = None):

--- a/dosma/core/io/format_io.py
+++ b/dosma/core/io/format_io.py
@@ -166,6 +166,8 @@ class DataReader(_StateMixin):
         """
         pass  # pragma: no cover
 
+    read = load  # pragma: no cover
+
     def __call__(self, *args, **kwargs):
         """Alias for :meth:`self.load`."""
         return self.load(*args, **kwargs)
@@ -191,6 +193,8 @@ class DataWriter(_StateMixin):
             file_path (str): File path to save volume to.
         """
         pass  # pragma: no cover
+
+    write = save  # pragma: no cover
 
     def __call__(self, *args, **kwargs):
         """Alias for :meth:`self.save`."""

--- a/dosma/core/io/format_io_utils.py
+++ b/dosma/core/io/format_io_utils.py
@@ -8,8 +8,11 @@ from typing import Union
 from dosma.core.io.dicom_io import DicomReader, DicomWriter
 from dosma.core.io.format_io import DataReader, DataWriter, ImageDataFormat
 from dosma.core.io.nifti_io import NiftiReader, NiftiWriter
+from dosma.core.med_volume import MedicalVolume
 
 __all__ = [
+    "read",
+    "write",
     "get_reader",
     "get_writer",
     "get_filepath_variations",
@@ -150,3 +153,59 @@ def generic_load(file_or_dir_path: Union[str, Path, os.PathLike], expected_num_v
         return vols[0]
 
     return vols
+
+
+def read(
+    path: Union[str, Path, os.PathLike],
+    data_format: ImageDataFormat = None,
+    unpack: bool = False,
+    **kwargs
+):
+    """Read MedicalVolume(s) from file.
+
+    Args:
+        path (str): File/directory path.
+        data_format (ImageDataFormat, optional): Data format (e.g. dicom, nifti, etc.).
+
+    Returns:
+        MedicalVolume | List[MedicalVolume]: Volume(s) loaded.
+
+    Raises:
+        FileNotFoundError: If file path or corresponding versions of file path not found.
+    """
+    if data_format is None:
+        data_format = ImageDataFormat.get_image_data_format(path)
+    elif isinstance(data_format, str):
+        data_format = ImageDataFormat[data_format]
+
+    out = get_reader(data_format).load(path, **kwargs)
+    if unpack and isinstance(out, (tuple, list)) and len(out) == 1:
+        out = out[0]
+    return out
+
+
+def write(
+    vol: MedicalVolume,
+    path: Union[str, Path, os.PathLike],
+    data_format: ImageDataFormat = None,
+    **kwargs
+):
+    """Write MedicalVolume to file.
+
+    Args:
+        vol (MedicalVolume): Volume to write.
+        path (str): File/directory path.
+        data_format (ImageDataFormat, optional): Data format (e.g. dicom, nifti, etc.).
+
+    Returns:
+        None
+
+    Raises:
+        FileNotFoundError: If file path or corresponding versions of file path not found.
+    """
+    if data_format is None:
+        data_format = ImageDataFormat.get_image_data_format(path)
+    elif isinstance(data_format, str):
+        data_format = ImageDataFormat[data_format]
+
+    get_writer(data_format).save(vol, path, **kwargs)

--- a/dosma/core/io/format_io_utils.py
+++ b/dosma/core/io/format_io_utils.py
@@ -3,7 +3,7 @@
 
 import os
 from pathlib import Path
-from typing import Union
+from typing import List, Union
 
 from dosma.core.io.dicom_io import DicomReader, DicomWriter
 from dosma.core.io.format_io import DataReader, DataWriter, ImageDataFormat
@@ -160,18 +160,26 @@ def read(
     data_format: ImageDataFormat = None,
     unpack: bool = False,
     **kwargs
-):
+) -> Union[MedicalVolume, List[MedicalVolume]]:
     """Read MedicalVolume(s) from file.
 
     Args:
         path (str): File/directory path.
-        data_format (ImageDataFormat, optional): Data format (e.g. dicom, nifti, etc.).
+        data_format (ImageDataFormat, optional): Data format
+            (e.g. ``'dicom'``, ``'nifti'``, etc.). Use this is disambiguate between different
+            data formats. If this function is not working, try using this argument.
+            If not provided, dosma will try to infer data format from file extension.
+        unpack (bool, optional): If ``True`` and only 1 volume is loaded, return a single
+            volume instead of a list of volumes. This only applied to dicom loading.
+        **kwargs: Additional keyword arguments passed to the data format reader.
 
     Returns:
         MedicalVolume | List[MedicalVolume]: Volume(s) loaded.
 
-    Raises:
-        FileNotFoundError: If file path or corresponding versions of file path not found.
+    Examples:
+        >>> dm.read("/path/to/multi-echo/dicom/folder", group_by="EchoNumbers")
+        >>> dm.read("/path/to/ct/dicom/folder")
+        >>> dm.read("/path/to/ct/nifti/file.nii.gz", mmap=True)
     """
     if data_format is None:
         data_format = ImageDataFormat.get_image_data_format(path)
@@ -189,16 +197,17 @@ def write(
     path: Union[str, Path, os.PathLike],
     data_format: ImageDataFormat = None,
     **kwargs
-):
+) -> None:
     """Write MedicalVolume to file.
 
     Args:
         vol (MedicalVolume): Volume to write.
         path (str): File/directory path.
-        data_format (ImageDataFormat, optional): Data format (e.g. dicom, nifti, etc.).
-
-    Returns:
-        None
+        data_format (ImageDataFormat, optional): Data format
+            (e.g. ``'dicom'``, ``'nifti'``, etc.). Use this is disambiguate between different
+            data formats. If this function is not working, try using this argument.
+            If not provided, dosma will try to infer data format from file extension.
+        **kwargs: Additional keyword arguments passed to the data format writer.
 
     Raises:
         FileNotFoundError: If file path or corresponding versions of file path not found.

--- a/dosma/core/io/nifti_io.py
+++ b/dosma/core/io/nifti_io.py
@@ -27,13 +27,14 @@ class NiftiReader(DataReader):
 
     data_format_code = ImageDataFormat.nifti
 
-    def load(self, file_path) -> MedicalVolume:
+    def load(self, file_path, mmap: bool = False) -> MedicalVolume:
         """Load volume from NIfTI file path.
 
         A NIfTI file should only correspond to one volume.
 
         Args:
             file_path (str): File path to NIfTI file.
+            mmap (bool): Whether to use memory mapping.
 
         Returns:
             MedicalVolume: Loaded volume.
@@ -55,6 +56,7 @@ class NiftiReader(DataReader):
             nib_img,
             affine_precision=AFFINE_DECIMAL_PRECISION,
             origin_precision=SCANNER_ORIGIN_DECIMAL_PRECISION,
+            mmap=mmap,
         )
 
     def __serializable_variables__(self) -> Collection[str]:

--- a/dosma/core/io/nifti_io.py
+++ b/dosma/core/io/nifti_io.py
@@ -60,6 +60,8 @@ class NiftiReader(DataReader):
     def __serializable_variables__(self) -> Collection[str]:
         return self.__dict__.keys()
 
+    read = load  # pragma: no cover
+
 
 class NiftiWriter(DataWriter):
     """A class for writing volumes in NIfTI format.
@@ -93,3 +95,5 @@ class NiftiWriter(DataWriter):
 
     def __serializable_variables__(self) -> Collection[str]:
         return self.__dict__.keys()
+
+    write = save  # pragma: no cover

--- a/dosma/core/med_volume.py
+++ b/dosma/core/med_volume.py
@@ -1158,6 +1158,9 @@ class MedicalVolume(NDArrayOperatorsMixin):
         return self._partial_clone(volume=volume, headers=headers)
 
     def __getitem__(self, _slice):
+        if isinstance(_slice, MedicalVolume):
+            _slice = _slice.reformat_as(self).A
+
         slicer = _SpatialFirstSlicer(self)
         try:
             _slice = slicer.check_slicing(_slice)

--- a/dosma/core/registration.py
+++ b/dosma/core/registration.py
@@ -409,7 +409,7 @@ def _elastix_register(
         if _use_mask and target_mask is not None:
             reg.inputs.fixed_mask = os.path.abspath(target_mask)
         if _use_mask and moving_mask is not None:
-            reg.inputs.target_mask = os.path.abspath(moving_mask)
+            reg.inputs.moving_mask = os.path.abspath(moving_mask)
         for k, v in kwargs.items():
             setattr(reg.inputs, k, v)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ nibabel
 nipype
 packaging
 pandas
-pydicom>=1.6.0,<=2.0.0
+pydicom>=1.6.0
 scikit-image
 scipy
 seaborn

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ REQUIRED = [
     "packaging",
     "pandas",
     # TODO Issue #57: Remove pydicom upper bound (https://github.com/ad12/DOSMA/issues/57)
-    "pydicom>=1.6.0,<=2.0.0",
+    "pydicom>=1.6.0",
     "scikit-image",
     "scipy",
     "seaborn",

--- a/tests/core/io/test_dicom_io.py
+++ b/tests/core/io/test_dicom_io.py
@@ -524,7 +524,7 @@ class TestDicomIO(ututils.TempPathMixin):
         out_dir = os.path.join(self.data_dirpath, "test_save_sort_by")
         dw = DicomWriter()
         dw.save(mv_base, out_dir, sort_by="InstanceNumber")
-        mv2 = dr.load(filepath)[0]
+        mv2 = dr.load(out_dir)[0]
         assert mv2.is_identical(mv_base)
 
         out_dir = os.path.join(self.data_dirpath, "test_save_no_headers")

--- a/tests/core/io/test_format_io_utils.py
+++ b/tests/core/io/test_format_io_utils.py
@@ -4,6 +4,7 @@ import unittest
 import nibabel.testing as nib_testing
 import pydicom.data as pydd
 
+import dosma as dm
 import dosma.core.io.format_io_utils as fio_utils
 from dosma.core.io.dicom_io import DicomReader, DicomWriter
 from dosma.core.io.format_io import ImageDataFormat
@@ -58,3 +59,58 @@ class TestFormatIOUtils(unittest.TestCase):
         vol = fio_utils.generic_load(dcm_data)[0]
         expected = DicomReader().load(dcm_data)[0]
         assert vol.is_identical(expected)
+
+
+def test_read():
+    nib_data = os.path.join(nib_testing.data_path, "example4d.nii.gz")
+    vol = dm.read(nib_data)
+    expected = NiftiReader().load(nib_data)
+    assert vol.is_identical(expected)
+
+    nib_data = os.path.join(nib_testing.data_path, "example4d.nii.gz")
+    vol = dm.read(nib_data, "nifti")
+    expected = NiftiReader().load(nib_data)
+    assert vol.is_identical(expected)
+
+    nib_data = os.path.join(nib_testing.data_path, "example4d.nii.gz")
+    vol = dm.read(nib_data, ImageDataFormat.nifti)
+    expected = NiftiReader().load(nib_data)
+    assert vol.is_identical(expected)
+
+    dcm_data = os.path.join(pydd.get_testdata_file("MR_small.dcm"))
+    vol = dm.read(dcm_data)[0]
+    expected = DicomReader().load(dcm_data)[0]
+    assert vol.is_identical(expected)
+
+    dcm_data = os.path.join(pydd.get_testdata_file("MR_small.dcm"))
+    vol = dm.read(dcm_data, unpack=True)
+    expected = DicomReader().load(dcm_data)[0]
+    assert vol.is_identical(expected)
+
+    dcm_data = os.path.join(pydd.get_testdata_file("MR_small.dcm"))
+    vol = dm.read(dcm_data, group_by="EchoNumbers")[0]
+    expected = DicomReader().load(dcm_data)[0]
+    assert vol.is_identical(expected)
+
+
+def test_write(tmpdir):
+    filepath = pydd.get_testdata_file("MR_small.dcm")
+    dr = DicomReader(group_by=None)
+    mv_base = dr.load(filepath)[0]
+
+    dicom_out_dir = tmpdir / "test_save_sort_by"
+    dm.write(mv_base, dicom_out_dir, sort_by="InstanceNumber")
+    mv2 = dr.load(dicom_out_dir)[0]
+    assert mv2.is_identical(mv_base)
+
+    nr = NiftiReader()
+    nifti_out_file = tmpdir / "test_save_sort_by.nii.gz"
+    dm.write(mv_base, nifti_out_file)
+    mv2 = nr.load(nifti_out_file)
+    assert mv2.is_identical(mv_base)
+
+    nr = NiftiReader()
+    nifti_out_file = tmpdir / "test_save_sort_by-nifti.nii.gz"
+    dm.write(mv_base, nifti_out_file, "nifti")
+    mv2 = nr.load(nifti_out_file)
+    assert mv2.is_identical(mv_base)

--- a/tests/core/test_med_volume.py
+++ b/tests/core/test_med_volume.py
@@ -550,6 +550,14 @@ class TestMedicalVolume(unittest.TestCase):
         with self.assertRaises(ValueError):
             mv = MedicalVolume.from_torch(tensor, self._AFFINE, to_complex=True)
 
+    def test_indexing(self):
+        # Index medical volume with another medical volume.
+        mv = MedicalVolume(np.ones((10, 20, 30)), np.eye(4))
+        mv_index = MedicalVolume(np.random.rand(10, 20, 30) > 0.5, np.eye(4))
+        mv[mv_index] = 0
+
+        assert np.all(mv.A[mv_index.A] == 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/core/test_med_volume.py
+++ b/tests/core/test_med_volume.py
@@ -100,7 +100,7 @@ class TestMedicalVolume(unittest.TestCase):
         assert mv_no_headers.headers() is None
         assert mv_no_headers.headers(flatten=True) is None
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises((KeyError, ValueError)):
             mv.get_metadata("foobar")
         assert mv.get_metadata("foobar", default=0) == 0
 

--- a/tests/core/test_med_volume.py
+++ b/tests/core/test_med_volume.py
@@ -6,6 +6,7 @@ import h5py
 import nibabel as nib
 import nibabel.testing as nib_testing
 import numpy as np
+import pydicom.data as pydd
 import SimpleITK as sitk
 
 from dosma.core.device import Device
@@ -190,6 +191,14 @@ class TestMedicalVolume(unittest.TestCase):
         img = mv.to_sitk(vdim=-1)
         assert np.all(sitk.GetArrayViewFromImage(img) == 0)
         assert img.GetSize() == (10, 20, 1)
+
+        filepath = pydd.get_testdata_file("MR_small.dcm")
+        dr = DicomReader(group_by=None)
+        mv = dr.load(filepath)[0]
+        mv2 = MedicalVolume.from_sitk(
+            mv.to_sitk(transpose_inplane=True), copy=True, transpose_inplane=True
+        )
+        assert mv2.is_identical(mv)
 
     @unittest.skipIf(not ututils.is_data_available(), "unittest data is not available")
     def test_to_from_sitk_dicom_convention(self):


### PR DESCRIPTION
### Changelist
- [x] Add `dosma.read` and `dosma.write` functions
- [x] Add aliases `read`/`write` for `load`/`save` in the DataReader/DataWriter classes
- [x] Remove upper bound on pydicom
- [x] Add support for memory-mapped arrays in `MedicalVolume`
- [x] Add `transpose_inplane` option for MedicalVolume <-> SimpleITK conversion to patch for DICOM convention

### Issues
Closes #57 ; closes #116 