### PR TITLE
Updated final interpolation to be cubic for interregister 

### DIFF
--- a/dosma/resources/elastix/params/parameters-affine-interregister.txt
+++ b/dosma/resources/elastix/params/parameters-affine-interregister.txt
@@ -58,7 +58,7 @@
 (ImageSampler "RandomCoordinate")
 (CheckNumberOfSamples "true")
 (NewSamplesEveryIteration "true")
-(FinalBSplineInterpolationOrder 0)
+(FinalBSplineInterpolationOrder 3)
 
 // *********************
 // * Output settings

--- a/dosma/resources/elastix/params/parameters-rigid-interregister.txt
+++ b/dosma/resources/elastix/params/parameters-rigid-interregister.txt
@@ -58,7 +58,7 @@
 (ImageSampler "RandomCoordinate")
 (CheckNumberOfSamples "true")
 (NewSamplesEveryIteration "true")
-(FinalBSplineInterpolationOrder 0)
+(FinalBSplineInterpolationOrder 3)
 
 // *********************
 // * Output settings


### PR DESCRIPTION
As it is these registration pipelines cause weird slicing artefacts that are resolved with a higher order final interpolation. 